### PR TITLE
Add Riley findings marker CI gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -60,10 +60,10 @@ Pending Riley review.
 
 <!--
 Replace "Pending Riley review." above with the findings table once Riley
-has reviewed. Use "No findings." if Riley reported zero. The literal HTML
-comment `<!-- riley:findings -->` MUST remain in the PR body — CI greps
-every PR for it via `npm run rules:check:pr-riley-marker` and will fail
-the build if it is missing. See rules/workflow-rules.md §6 and
+has reviewed. Use "No findings." if Riley reported zero. The marker line
+above (the riley:findings HTML comment) MUST remain in the PR body — CI
+greps every PR for it via npm run rules:check:pr-riley-marker and will
+fail the build if it is missing. See rules/workflow-rules.md §6 and
 personas/riley.md.
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,6 +53,20 @@ front prevents Riley from "discovering" them as findings.
 Write "None" if there are none.
 -->
 
+## Riley findings
+
+<!-- riley:findings -->
+Pending Riley review.
+
+<!--
+Replace "Pending Riley review." above with the findings table once Riley
+has reviewed. Use "No findings." if Riley reported zero. The literal HTML
+comment `<!-- riley:findings -->` MUST remain in the PR body — CI greps
+every PR for it via `npm run rules:check:pr-riley-marker` and will fail
+the build if it is missing. See rules/workflow-rules.md §6 and
+personas/riley.md.
+-->
+
 ## Riley auto-merge gate
 
 This PR will be auto-merged if Riley returns zero CRITICAL or HIGH findings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
         run: npm run rules:check
       - name: Generated API freshness
         run: npm run api:check
+      - name: Riley findings marker (PRs only)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/check-pr-riley-marker.mjs
       - name: Lint full repo
         run: npm run lint
       - name: Typecheck full repo

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "rules:check:unsafe-casts": "node scripts/check-unsafe-casts.mjs --warn-only",
     "rules:check:shared-ui-controls": "node scripts/check-shared-ui-controls.mjs --warn-only",
     "rules:check:form-query-mirror": "node scripts/check-form-query-mirror.mjs --warn-only",
+    "rules:check:pr-riley-marker": "node scripts/check-pr-riley-marker.mjs",
     "rules:check": "npm run rules:check:no-mocked-api && npm run rules:check:route-discipline && npm run rules:check:test-traceability && npm run rules:check:test-disable && npm run rules:check:unsafe-casts && npm run rules:check:shared-ui-controls && npm run rules:check:form-query-mirror",
     "typecheck": "turbo run typecheck --filter=@poolmaster/shared --filter=@poolmaster/core-api --filter=@poolmaster/poolmaster --force",
     "test": "jest --config tests/jest.config.js",

--- a/personas/riley.md
+++ b/personas/riley.md
@@ -29,6 +29,26 @@ acceptance decisions.
 
 This project's branch + PR + Riley + auto-merge flow (per `rules/workflow-rules.md` §6) treats Riley's findings table as the merge signal. **Zero CRITICAL or HIGH findings = the implementing agent auto-merges. Any CRITICAL or HIGH finding blocks merge.** Severity calibration is therefore load-bearing — see *Severity Calibration* below.
 
+### Findings marker in the PR body
+
+Once Riley produces a findings table, the implementing agent must paste it into the PR body under the literal HTML comment `<!-- riley:findings -->`. CI greps every PR body for that marker via `npm run rules:check:pr-riley-marker`; a PR without it cannot merge. The marker is auditable proof Riley was actually invoked.
+
+The expected PR-body section format:
+
+```markdown
+## Riley findings
+
+<!-- riley:findings -->
+
+| Severity | Category | Finding | Location |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+(Or, when Riley reported zero blockers: "No findings.")
+```
+
+The marker line itself (`<!-- riley:findings -->`) is non-negotiable; the table format above is a recommended layout but Riley may use whatever shape best fits the slice.
+
 ## Required References
 
 - `AGENTS.md`

--- a/rules/workflow-rules.md
+++ b/rules/workflow-rules.md
@@ -732,12 +732,9 @@ When an implementing persona (Brad, Fran, Archie, Dom, etc.) finishes a slice, t
 2. **Run all required local gates** (`rules/testing-rules.md §3`). Do not push on a "likely green" assumption.
 3. **Commit** with the Beads story ID in the footer: `pool-master-NNN`. One slice = one commit (squash later in the PR if multiple working commits exist).
 4. **Push the branch** to origin.
-5. **Open a PR** with `gh pr create`. Title: short imperative summary. Body: link to the parent Beads epic, the slice's Beads story (`pool-master-NNN`), one-paragraph context, and the gates that were run. For defect-fix slices, the PR body must explicitly state that the failing test was observed to fail before the fix landed.
-6. **Record the Riley review marker** in the PR body once PR-only flow is
-   confirmed for the repo: `<!-- riley:findings -->`. This marker is only an
-   auditable placeholder until the CI marker gate lands; do not treat it as a
-   substitute for the actual review.
-7. **Spawn Riley** as a subagent using the canonical spawn prompt below — Riley's review quality depends on what you pass.
+5. **Open a PR** with `gh pr create`. Title: short imperative summary. Body: link to the parent Beads epic, the slice's Beads story (`pool-master-NNN`), one-paragraph context, and the gates that were run. For defect-fix slices, the PR body must explicitly state that the failing test was observed to fail before the fix landed. The PR body must also include the Riley findings marker section described in step 7 — open the PR with the placeholder text in place; the actual findings table replaces the placeholder once Riley has reviewed.
+6. **Spawn Riley** as a subagent using the canonical spawn prompt below — Riley's review quality depends on what you pass.
+7. **Record Riley's findings in the PR body.** Replace the placeholder under the literal HTML comment `<!-- riley:findings -->` with Riley's findings table (or "No findings." if Riley reported zero). The marker is non-negotiable — CI greps the PR body for it on every PR via `npm run rules:check:pr-riley-marker`, and a PR without it cannot merge. The marker is auditable proof the review happened, not a substitute for the review itself.
 8. **Read Riley's findings table.** Then:
    - **Zero blocker-severity findings** (CRITICAL or HIGH) → `gh pr merge --squash --delete-branch`. Close the Beads story with a closing note per §1 *Beads conventions: story notes*. Return to the user with a summary.
    - **Any blocker-severity findings** → **do not merge**. Surface the findings to the user, await direction (fix-and-re-review, merge-anyway-with-justification, or park).

--- a/scripts/check-pr-riley-marker.mjs
+++ b/scripts/check-pr-riley-marker.mjs
@@ -1,0 +1,51 @@
+import { spawnSync } from 'node:child_process';
+
+const MARKER = '<!-- riley:findings -->';
+
+const prNumber =
+  process.argv[2] ??
+  process.env.PR_NUMBER ??
+  process.env.GITHUB_PR_NUMBER ??
+  null;
+
+if (!prNumber) {
+  console.log(
+    'Riley findings marker check: not running in a PR context (no PR number provided). Skipping.',
+  );
+  process.exit(0);
+}
+
+const result = spawnSync(
+  'gh',
+  ['pr', 'view', String(prNumber), '--json', 'body', '--jq', '.body'],
+  { encoding: 'utf8' },
+);
+
+if (result.status !== 0) {
+  console.error(`Failed to fetch PR #${prNumber}:`);
+  if (result.stderr) console.error(result.stderr.trim());
+  process.exit(1);
+}
+
+const body = (result.stdout ?? '').toString();
+
+if (!body.includes(MARKER)) {
+  console.error(`PR #${prNumber} body is missing the Riley findings marker.`);
+  console.error('');
+  console.error('Add a section like this to the PR body:');
+  console.error('');
+  console.error('    ## Riley findings');
+  console.error('');
+  console.error(`    ${MARKER}`);
+  console.error('    No findings.');
+  console.error('');
+  console.error(
+    'Replace "No findings." with the findings table once Riley has reviewed.',
+  );
+  console.error(
+    'See rules/workflow-rules.md §6 and personas/riley.md for the marker format.',
+  );
+  process.exit(1);
+}
+
+console.log(`PR #${prNumber} contains the Riley findings marker.`);

--- a/scripts/check-pr-riley-marker.sh
+++ b/scripts/check-pr-riley-marker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -eu
+node scripts/check-pr-riley-marker.mjs "$@"


### PR DESCRIPTION
## Slice intent

Adds the Riley findings marker CI gate that closes `pool-master-1y8.25` (E1b) and the parent rule-enforcement epic. The previous slice (PR #1) configured GitHub branch protection (`1y8.24` / E1a precondition); with that in place, the marker requirement is now meaningful — every PR must record evidence that Riley actually reviewed it.

This PR is the first one to exercise the gate against itself.

## Beads linkage

- **Parent epic:** `pool-master-1y8` — Rule-enforcement hardening (post-review)
- **Slice story:** `pool-master-1y8.25` — E1b Riley findings marker requirement
- **Closes:** epic `pool-master-1y8` (24/25 → 25/25 after this merges)

## Use-case / business-rule / defect IDs covered

Workflow infrastructure slice — no UC/BR/defect ID applies. The change references `rules/workflow-rules.md §6` and `rules/testing-rules.md §1A` indirectly (the marker is the auditable evidence that Riley's review happened, supporting the §1A traceability discipline).

## What changed

- `scripts/check-pr-riley-marker.{mjs,sh}` — fetches the PR body via `gh pr view --json body --jq .body` and fails if the literal HTML comment `<!-- riley:findings -->` is absent. Skips silently in non-PR contexts (no `PR_NUMBER`).
- `package.json` — adds `rules:check:pr-riley-marker` script. **Not** bundled into the `rules:check` chain since the check only makes sense in PR context.
- `.github/workflows/ci.yml` — adds a `Riley findings marker (PRs only)` step in `lint-typecheck`, gated on `github.event_name == 'pull_request'`. Receives `GH_TOKEN` and `PR_NUMBER` from the workflow context.
- `rules/workflow-rules.md §6` — promotes the marker text from a conditional placeholder to a hard requirement. Reorders the closeout protocol so "Spawn Riley" precedes "Record findings in PR body."
- `personas/riley.md` — adds a "Findings marker in the PR body" section with the expected format.
- `.github/pull_request_template.md` — adds a Riley findings section pre-populated with the marker, so PR authors don't have to remember it.

## Gates run

- [x] `npm run rules:check` (passes — marker check intentionally not in chain)
- [x] `npm run rules:check:pr-riley-marker` against PR #1 (correctly failed — PR #1 lacked the marker, demonstrating the gate works)
- [x] Manual no-PR-context invocation (correctly skipped with exit 0)
- [x] `npm run api:check`
- [x] `npm run lint`
- [x] `npm run typecheck`

## Known concerns

- This PR is the first to exercise the marker gate against itself. The marker is included in this PR body (see "Riley findings" section below). If the gate fails on this PR, that is the bug to fix.
- The `PR_NUMBER` env var passed to the script comes from `github.event.pull_request.number`. On `push` events to `main`, the gate is skipped via the `if:` condition — `gh pr view` would not have a PR number to query.

## Riley findings

<!-- riley:findings -->
| Severity | Category | Finding | Location |
|---|---|---|---|
| LOW | SCOPE | `scripts/check-pr-riley-marker.sh` shim is not referenced anywhere; only the `.mjs` is invoked. Harmless and consistent with the convention used by every other rule scanner shim, but technically dead surface. | `scripts/check-pr-riley-marker.sh` |
| LOW | STALE | ~~The PR template instruction comment on lines ~61-68 embeds the literal string `<!-- riley:findings -->` inside an outer `<!-- ... -->` block. GitHub markdown's HTML-comment parser may close the outer comment on the inner `-->`, leaking the explanatory text into the rendered PR body.~~ **Fixed in commit `e4d75c54`** — replaced the literal-marker mention inside the comment with a non-HTML description; CI grep target unchanged. | `.github/pull_request_template.md:64` |

**No CRITICAL or HIGH findings. Riley recommendation: ACCEPT.**

Two known concerns confirmed as non-issues:

- `rules:check:pr-riley-marker` is correctly excluded from the `rules:check` chain (PR-context-only).
- Not threading the new script through `rule-check-utils.mjs` is justified — the utility is for filesystem walks; this script calls the GitHub API.

## Riley auto-merge gate

This PR will be auto-merged if Riley returns zero CRITICAL or HIGH findings.
Any blocker-severity finding pauses the merge for user review.

Special pause condition flagged: this slice modifies `rules/`, `personas/`, AND `.github/workflows/`. Per the PR template, **user approval is required regardless of Riley's outcome.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
