### PR TITLE
[pool-master-rop.78.6] ContestEntryPick unification + mapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test:api": "jest --config tests/jest.config.js tests/api",
     "format": "prettier --write .",
     "api:export": "npm run build --workspace @poolmaster/shared && node --import tsx packages/core-api/scripts/export-openapi.ts",
-    "api:generate": "npx @hey-api/openapi-ts -f packages/shared/openapi-ts.config.ts",
+    "api:generate": "npx @hey-api/openapi-ts -f packages/shared/openapi-ts.config.ts && npx openapi-typescript packages/shared/generated/openapi.json -o packages/shared/generated/api-types.ts",
     "api:check": "node scripts/check-openapi-fresh.mjs",
     "api:validate": "node --import tsx scripts/validate-openapi-spec.ts",
     "api:refresh": "npm run api:export && npm run api:generate"

--- a/packages/core-api/src/mappers/contest-entry-picks.mapper.ts
+++ b/packages/core-api/src/mappers/contest-entry-picks.mapper.ts
@@ -1,0 +1,83 @@
+/**
+ * ContestEntryPick mappers — persistence row → canonical DTO.
+ *
+ * The Prisma row is the pick's raw persistence shape (with Decimal cost,
+ * nullable optional columns, Date timestamps). The DTO surface uses ISO
+ * datetime strings, primitive `number | null` for nullable optionals, and
+ * the typed `ContestFormat` enum.
+ *
+ * See plans/117 §4.3 (unified pick model), §7.1 (denormalization invariant),
+ * §12.1 (canonical DTO surface).
+ */
+
+import type { ContestEntryPick } from '@poolmaster/shared/domain';
+import type { ContestEntryPickDto } from '@poolmaster/shared/dto';
+
+/**
+ * Shape of the Prisma row read by `prisma.contestEntryPick.findUnique` /
+ * `findMany` / `create`. Decimals arrive as Prisma `Decimal`-like objects
+ * with `toNumber()`; we accept the broader `unknown` here and narrow at
+ * runtime so the mapper works against both the Prisma client and hand-built
+ * fixtures in tests.
+ */
+export interface ContestEntryPickRow {
+  id: string;
+  entryId: string;
+  sportEventParticipantId: string;
+  contestFormat: string;
+  period: number | null;
+  slot: number | null;
+  tier: string | null;
+  cost: { toNumber(): number } | number | null;
+  isAutoPicked: boolean;
+  draftRound: number | null;
+  draftPickNumber: number | null;
+  pickedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function decimalToNumber(value: { toNumber(): number } | number | null): number | null {
+  if (value === null) return null;
+  if (typeof value === 'number') return value;
+  return value.toNumber();
+}
+
+export function mapContestEntryPickToDto(row: ContestEntryPickRow): ContestEntryPickDto {
+  return {
+    id: row.id,
+    entryId: row.entryId,
+    sportEventParticipantId: row.sportEventParticipantId,
+    contestFormat: row.contestFormat,
+    period: row.period,
+    slot: row.slot,
+    tier: row.tier,
+    cost: decimalToNumber(row.cost),
+    isAutoPicked: row.isAutoPicked,
+    draftRound: row.draftRound,
+    draftPickNumber: row.draftPickNumber,
+    pickedAt: row.pickedAt.toISOString(),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+/** Domain-shape ContestEntryPick (no DTO, used by service-internal code). */
+export function mapContestEntryPickRowToDomain(row: ContestEntryPickRow): ContestEntryPick {
+  return {
+    id: row.id,
+    entryId: row.entryId,
+    sportEventParticipantId: row.sportEventParticipantId,
+    contestFormat: row.contestFormat as ContestEntryPick['contestFormat'],
+    period: row.period ?? undefined,
+    slot: row.slot ?? undefined,
+    tier: row.tier ?? undefined,
+    cost: decimalToNumber(row.cost) ?? undefined,
+    isAutoPicked: row.isAutoPicked,
+    draftRound: row.draftRound ?? undefined,
+    draftPickNumber: row.draftPickNumber ?? undefined,
+    pickedAt: row.pickedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/core-api/src/mappers/index.ts
+++ b/packages/core-api/src/mappers/index.ts
@@ -1,6 +1,7 @@
 export * from './auth.mapper';
 export * from './leagues.mapper';
 export * from './contests.mapper';
+export * from './contest-entry-picks.mapper';
 export * from './participants.mapper';
 export * from './standings.mapper';
 export * from './account-consent.mapper';

--- a/packages/core-api/src/modules/contest-entry-picks/index.ts
+++ b/packages/core-api/src/modules/contest-entry-picks/index.ts
@@ -1,0 +1,6 @@
+export {
+  ContestEntryPickService,
+  ContestEntryPickEntryMissingError,
+  ContestEntryPickContestMissingError,
+} from './service';
+export type { ContestEntryPickInsertInput } from './types';

--- a/packages/core-api/src/modules/contest-entry-picks/service.ts
+++ b/packages/core-api/src/modules/contest-entry-picks/service.ts
@@ -1,0 +1,115 @@
+/**
+ * ContestEntryPickService — service-layer enforcement of the contestFormat
+ * denormalization invariant from plans/117 §7.1.
+ *
+ * Background. The unified ContestEntryPick table denormalizes
+ * `Contest.contestFormat` onto each pick row so Postgres partial unique
+ * indexes (which can only predicate on local columns) can enforce the
+ * per-format pick uniqueness rules. This service is the single insert path
+ * that guarantees the denormalized column always matches the parent contest;
+ * routes / draft-engine code go through `createPick` instead of touching
+ * `prisma.contestEntryPick.create` directly.
+ *
+ * Per plans/117 §7.1: "pick-creation always reads Contest.contestFormat from
+ * the parent contest and writes it to the pick row. No insert path bypasses
+ * this."
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import type { FastifyBaseLogger } from 'fastify';
+import type {
+  ContestEntryPickDto,
+  ContestEntryPickInsertInput,
+} from './types';
+import { mapContestEntryPickToDto } from '../../mappers/contest-entry-picks.mapper';
+
+export class ContestEntryPickEntryMissingError extends Error {
+  constructor(entryId: string) {
+    super(`ContestEntry ${entryId} not found; cannot create pick.`);
+    this.name = 'ContestEntryPickEntryMissingError';
+  }
+}
+
+export class ContestEntryPickContestMissingError extends Error {
+  constructor(contestId: string) {
+    super(`Contest ${contestId} not found; cannot resolve contestFormat for pick.`);
+    this.name = 'ContestEntryPickContestMissingError';
+  }
+}
+
+export class ContestEntryPickService {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly logger?: FastifyBaseLogger,
+  ) {}
+
+  /**
+   * Insert a ContestEntryPick. Resolves `contestFormat` from the parent
+   * contest in the same transaction so the denormalized column is always
+   * consistent. Callers pass per-format optional metadata (period / slot /
+   * tier / cost / draftRound / draftPickNumber / isAutoPicked); the service
+   * is format-agnostic — the partial unique indexes from plans/117 §7.1
+   * enforce the per-format combination rules at the database layer.
+   */
+  async createPick(input: ContestEntryPickInsertInput): Promise<ContestEntryPickDto> {
+    return this.prisma.$transaction(async (tx) => {
+      const entry = await tx.contestEntry.findUnique({
+        where: { id: input.entryId },
+        select: { contestId: true },
+      });
+      if (!entry) {
+        this.logger?.warn(
+          { action: 'contestEntryPick.create.missingEntry', data: { entryId: input.entryId } },
+          'Cannot create pick — owning entry not found',
+        );
+        throw new ContestEntryPickEntryMissingError(input.entryId);
+      }
+
+      const contest = await tx.contest.findUnique({
+        where: { id: entry.contestId },
+        select: { contestFormat: true },
+      });
+      if (!contest) {
+        this.logger?.error(
+          {
+            action: 'contestEntryPick.create.missingContest',
+            data: { entryId: input.entryId, contestId: entry.contestId },
+          },
+          'Cannot create pick — parent contest not found',
+        );
+        throw new ContestEntryPickContestMissingError(entry.contestId);
+      }
+
+      const row = await tx.contestEntryPick.create({
+        data: {
+          entryId: input.entryId,
+          sportEventParticipantId: input.sportEventParticipantId,
+          contestFormat: contest.contestFormat,
+          period: input.period ?? null,
+          slot: input.slot ?? null,
+          tier: input.tier ?? null,
+          cost: input.cost ?? null,
+          isAutoPicked: input.isAutoPicked ?? false,
+          draftRound: input.draftRound ?? null,
+          draftPickNumber: input.draftPickNumber ?? null,
+          ...(input.pickedAt !== undefined ? { pickedAt: input.pickedAt } : {}),
+        },
+      });
+
+      this.logger?.info(
+        {
+          action: 'contestEntryPick.create.success',
+          data: {
+            entryId: input.entryId,
+            contestId: entry.contestId,
+            contestFormat: contest.contestFormat,
+            pickId: row.id,
+          },
+        },
+        'Created contest entry pick with denormalized contestFormat',
+      );
+
+      return mapContestEntryPickToDto(row);
+    });
+  }
+}

--- a/packages/core-api/src/modules/contest-entry-picks/types.ts
+++ b/packages/core-api/src/modules/contest-entry-picks/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal types for the ContestEntryPick module. The DTO is re-exported
+ * from `@poolmaster/shared/dto`; the insert input is service-internal and
+ * deliberately omits `contestFormat` (the service resolves it from the
+ * parent contest per plans/117 §7.1).
+ */
+
+export type { ContestEntryPickDto } from '@poolmaster/shared/dto';
+
+export interface ContestEntryPickInsertInput {
+  entryId: string;
+  sportEventParticipantId: string;
+  /** Per-format period — week (SURVIVOR), draft round (BRACKET). */
+  period?: number | null;
+  /** Per-format slot — matchup index, confidence rank, predicted position. */
+  slot?: number | null;
+  /** Selection tier (tiered ROSTER). */
+  tier?: string | null;
+  /** Budget cost (budget ROSTER). */
+  cost?: number | null;
+  /** Snake-draft round number (existing draft mechanism). */
+  draftRound?: number | null;
+  /** Snake-draft pick order (existing draft mechanism). */
+  draftPickNumber?: number | null;
+  /** Whether the pick was auto-assigned (snake-draft auto-pick, missed-week loss). */
+  isAutoPicked?: boolean;
+  /** Override the default `pickedAt` (now). Used by integration fixtures. */
+  pickedAt?: Date;
+}

--- a/packages/core-api/src/modules/drafts/routes.ts
+++ b/packages/core-api/src/modules/drafts/routes.ts
@@ -26,6 +26,7 @@ import {
 import {
   PrismaContestEntryRepository,
 } from '../../adapters';
+import { ContestEntryPickService } from '../contest-entry-picks';
 import { createErrorEnvelope } from '../../core/error-handler';
 import { getAppPrisma } from '../../core/prisma-context';
 import crypto from 'node:crypto';
@@ -1168,15 +1169,16 @@ export async function draftsModule(fastify: FastifyInstance): Promise<void> {
         },
       });
 
-      await prisma.contestEntryPick.create({
-        data: {
-          entryId,
-          sportEventParticipantId: participantId,
-          contestFormat: 'ROSTER',
-          draftRound,
-          draftPickNumber: globalPickCount + 1,
-          isAutoPicked: false,
-        },
+      // pool-master-rop.78.6 — go through ContestEntryPickService so the
+      // denormalized contestFormat is read from the parent contest in the same
+      // transaction (plans/117 §7.1 — "no insert path bypasses this").
+      const pickService = new ContestEntryPickService(prisma, fastify.log);
+      await pickService.createPick({
+        entryId,
+        sportEventParticipantId: participantId,
+        draftRound,
+        draftPickNumber: globalPickCount + 1,
+        isAutoPicked: false,
       });
 
       return buildRosterSelectionResponse(prisma, context, entryId, requestUserId);

--- a/packages/core-api/src/modules/drafts/routes.ts
+++ b/packages/core-api/src/modules/drafts/routes.ts
@@ -793,6 +793,9 @@ async function buildDraftStateResponse(
 export async function draftsModule(fastify: FastifyInstance): Promise<void> {
   const prisma = getAppPrisma(fastify);
   const engine = new SnakeDraftEngine(fastify.log);
+  // Module-scoped (one per fastify register) — see plans/117 §7.1; the service
+  // resolves Contest.contestFormat in the same Prisma transaction at insert time.
+  const pickService = new ContestEntryPickService(prisma, fastify.log);
 
   fastify.get('/:contestId', {
     schema: {
@@ -1172,7 +1175,6 @@ export async function draftsModule(fastify: FastifyInstance): Promise<void> {
       // pool-master-rop.78.6 — go through ContestEntryPickService so the
       // denormalized contestFormat is read from the parent contest in the same
       // transaction (plans/117 §7.1 — "no insert path bypasses this").
-      const pickService = new ContestEntryPickService(prisma, fastify.log);
       await pickService.createPick({
         entryId,
         sportEventParticipantId: participantId,

--- a/packages/shared/db/index.ts
+++ b/packages/shared/db/index.ts
@@ -22,7 +22,6 @@ export type {
   ParticipantProviderMappingRepository,
   ParticipantRepository,
   ParticipantSearchFilters,
-  ContestEntryPickRepository,
   SeasonRepository,
   SportRepository,
   SquadMembershipRepository,

--- a/packages/shared/db/ports.ts
+++ b/packages/shared/db/ports.ts
@@ -12,7 +12,6 @@ import type {
   DraftPickHistory,
   DraftSession,
   League,
-  ContestEntryPick,
   LeagueInvitation,
   LeagueMembership,
   Participant,
@@ -159,11 +158,6 @@ export interface ContestEntryRepository {
   create(entry: Omit<ContestEntry, 'id' | 'createdAt' | 'updatedAt'>): Promise<ContestEntry>;
   update(id: string, updates: Partial<ContestEntry>): Promise<ContestEntry>;
   delete(id: string): Promise<void>;
-}
-
-export interface ContestEntryPickRepository {
-  findByEntry(entryId: string): Promise<ContestEntryPick[]>;
-  create(pick: Omit<ContestEntryPick, 'id' | 'createdAt' | 'updatedAt'>): Promise<ContestEntryPick>;
 }
 
 // --- Draft Session (Snake Draft only) ---

--- a/packages/shared/dto/contests.dto.ts
+++ b/packages/shared/dto/contests.dto.ts
@@ -210,6 +210,44 @@ export const ContestEntryDtoSchema = z.object({
 }).describe('Contest entry summary.');
 export type ContestEntryDto = z.infer<typeof ContestEntryDtoSchema>;
 
+/**
+ * Canonical raw-row DTO for ContestEntryPick. The persistence shape of a single
+ * pick on a contest entry, unified across contest formats per plans/117 §4.3.
+ * Optional metadata (period, slot, tier, cost) is populated based on the
+ * parent Contest.contestFormat — see plans/117 §7.1 for the per-format mapping.
+ *
+ * `ContestEntryParticipantDetailDtoSchema` is the richer read shape used by
+ * entry-detail and leaderboard surfaces (joins SportEventParticipant +
+ * Participant for display names); this schema is the underlying pick row.
+ */
+export const ContestEntryPickDtoSchema = z.object({
+  id: z.string().describe('Pick identifier.'),
+  entryId: z.string().describe('Owning contest entry identifier.'),
+  sportEventParticipantId: z.string().describe(
+    'Per-event participant the pick refers to (Sport-event-participant row, not the canonical Participant).',
+  ),
+  contestFormat: z.enum(Object.values(ContestFormat) as [string, ...string[]]).describe(
+    'Denormalized from parent Contest.contestFormat. Plans/117 §7.1 — enables per-format partial unique indexes that Postgres cannot predicate on joined parent columns.',
+  ),
+  period: z.number().int().nullable().describe(
+    'Per-format period: week (SURVIVOR), draft round (BRACKET), or omitted (ROSTER). Plans/117 §7.1.',
+  ),
+  slot: z.number().int().nullable().describe(
+    'Per-format slot: matchup index (BRACKET), confidence rank (PICKEM_CONFIDENCE), predicted position (PREDICT_TOP_N), or omitted (ROSTER, SURVIVOR). Plans/117 §7.1.',
+  ),
+  tier: z.string().nullable().describe('Selection tier (tiered ROSTER); null otherwise.'),
+  cost: z.number().nullable().describe('Budget cost (budget ROSTER); null otherwise.'),
+  isAutoPicked: z.boolean().describe(
+    'Whether this pick was auto-assigned (snake-draft auto-pick, Survivor missed-week auto-loss, etc.).',
+  ),
+  draftRound: z.number().int().nullable().describe('Snake-draft round; null outside snake-draft mechanism.'),
+  draftPickNumber: z.number().int().nullable().describe('Snake-draft pick order; null outside snake-draft mechanism.'),
+  pickedAt: z.string().datetime().describe('When the pick was made (or auto-picked).'),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).describe('Raw ContestEntryPick row used by persistence-aware surfaces.');
+export type ContestEntryPickDto = z.infer<typeof ContestEntryPickDtoSchema>;
+
 export const ContestEntryParticipantDetailDtoSchema = z.object({
   pickId: z.string(),
   sportEventParticipantId: z.string(),

--- a/packages/shared/generated/api-types.ts
+++ b/packages/shared/generated/api-types.ts
@@ -1350,46 +1350,6 @@ export interface paths {
         patch: operations["updateParticipant"];
         trace?: never;
     };
-    "/api/v1/participants/{id}/seasons": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get all season records for a participant
-         * @description Returns every stored season record for the participant so history and scoring surfaces can inspect longitudinal performance.
-         */
-        get: operations["getParticipantSeasonRecords"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/participants/{id}/seasons/{season}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get a specific season record for a participant
-         * @description Returns the participant season record for a specific season value.
-         */
-        get: operations["getParticipantSeasonRecord"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/contests/{contestId}/standings/": {
         parameters: {
             query?: never;
@@ -3037,7 +2997,7 @@ export interface paths {
         put?: never;
         /**
          * Trigger data sync for a sport
-         * @description Triggers a provider sync for the requested sport so ingestion jobs can be run manually from operational tools.
+         * @description Triggers a root-admin provider sync for the requested sport so ingestion jobs can be run manually from operational tools.
          */
         post: operations["syncSportData"];
         delete?: never;
@@ -3057,7 +3017,7 @@ export interface paths {
         put?: never;
         /**
          * Trigger feed-aware sync for a specific sport event
-         * @description Triggers explicit feed sync work for a single sport event such as participant hydration, live score polling, or final results.
+         * @description Triggers root-admin explicit feed sync work for a single sport event such as participant hydration, live score polling, or final results.
          */
         post: operations["syncEventData"];
         delete?: never;
@@ -3077,7 +3037,7 @@ export interface paths {
         put?: never;
         /**
          * Ingest scores for a sport event
-         * @description Triggers score ingestion for a specific sport event when manual or ad hoc score refresh is required.
+         * @description Triggers root-admin score ingestion for a specific sport event when manual or ad hoc score refresh is required.
          */
         post: operations["ingestEventScores"];
         delete?: never;
@@ -3097,7 +3057,7 @@ export interface paths {
         put?: never;
         /**
          * Ingest results for a sport event
-         * @description Triggers result ingestion for a specific sport event when final or corrected event outcomes need to be pulled in.
+         * @description Triggers root-admin result ingestion for a specific sport event when final or corrected event outcomes need to be pulled in.
          */
         post: operations["ingestEventResults"];
         delete?: never;
@@ -3117,7 +3077,7 @@ export interface paths {
         put?: never;
         /**
          * Ingest odds for a sport
-         * @description Triggers odds ingestion for the requested sport so odds-driven contest flows can refresh market data.
+         * @description Triggers root-admin odds ingestion for the requested sport so odds-driven contest flows can refresh market data.
          */
         post: operations["ingestSportOdds"];
         delete?: never;
@@ -4681,6 +4641,25 @@ export interface operations {
                     };
                 };
             };
+            /** @description Standard API error envelope. */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
         };
     };
     generateInviteLink: {
@@ -5437,7 +5416,40 @@ export interface operations {
                 content: {
                     "application/json": {
                         entries: {
-                            [key: string]: unknown;
+                            /** @description Audit-log entry id. */
+                            id: string;
+                            /** @description League this entry belongs to. */
+                            leagueId: string;
+                            /** @description Contest this entry references when the action is contest-scoped. */
+                            contestId?: string;
+                            /** @description User id of the commissioner / actor that performed the action. */
+                            actorId: string;
+                            /** @description Action verb in dotted form (e.g., "league.member.role.changed"). */
+                            action: string;
+                            /**
+                             * @description Audit-log entry category — broad classification of the action that produced this entry.
+                             * @enum {string}
+                             */
+                            category: "LEAGUE" | "CONTEST" | "DRAFT" | "SCORING" | "PAYOUT" | "MEMBER" | "COMMUNICATION";
+                            /** @description Human-readable description of what happened. */
+                            description: string;
+                            /** @description Opaque snapshot of relevant entity state BEFORE the action. Shape varies by category; treat as audit data, not as a typed contract. */
+                            beforeState?: {
+                                [key: string]: unknown;
+                            };
+                            /** @description Opaque snapshot of relevant entity state AFTER the action. Shape varies by category; treat as audit data, not as a typed contract. */
+                            afterState?: {
+                                [key: string]: unknown;
+                            };
+                            /** @description Optional human-supplied reason / justification for the action. */
+                            reason?: string;
+                            /** @description IP address from which the action originated, when available. */
+                            ipAddress?: string;
+                            /**
+                             * Format: date-time
+                             * @description When the audit entry was recorded.
+                             */
+                            createdAt: string;
                         }[];
                     };
                 };
@@ -5482,7 +5494,40 @@ export interface operations {
                 content: {
                     "application/json": {
                         entries: {
-                            [key: string]: unknown;
+                            /** @description Audit-log entry id. */
+                            id: string;
+                            /** @description League this entry belongs to. */
+                            leagueId: string;
+                            /** @description Contest this entry references when the action is contest-scoped. */
+                            contestId?: string;
+                            /** @description User id of the commissioner / actor that performed the action. */
+                            actorId: string;
+                            /** @description Action verb in dotted form (e.g., "league.member.role.changed"). */
+                            action: string;
+                            /**
+                             * @description Audit-log entry category — broad classification of the action that produced this entry.
+                             * @enum {string}
+                             */
+                            category: "LEAGUE" | "CONTEST" | "DRAFT" | "SCORING" | "PAYOUT" | "MEMBER" | "COMMUNICATION";
+                            /** @description Human-readable description of what happened. */
+                            description: string;
+                            /** @description Opaque snapshot of relevant entity state BEFORE the action. Shape varies by category; treat as audit data, not as a typed contract. */
+                            beforeState?: {
+                                [key: string]: unknown;
+                            };
+                            /** @description Opaque snapshot of relevant entity state AFTER the action. Shape varies by category; treat as audit data, not as a typed contract. */
+                            afterState?: {
+                                [key: string]: unknown;
+                            };
+                            /** @description Optional human-supplied reason / justification for the action. */
+                            reason?: string;
+                            /** @description IP address from which the action originated, when available. */
+                            ipAddress?: string;
+                            /**
+                             * Format: date-time
+                             * @description When the audit entry was recorded.
+                             */
+                            createdAt: string;
                         }[];
                     };
                 };
@@ -7776,7 +7821,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "DRAFT" | "OPEN" | "DRAFTING" | "LOCKED" | "ACTIVE" | "COMPLETED" | "CANCELLED";
                             /** @enum {string} */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /** @enum {string} */
                             selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK" | "OPEN_SELECTION" | "PICK_EM" | "BRACKET_PICK_EM";
                             /** @enum {string} */
@@ -7815,8 +7860,11 @@ export interface operations {
                 "application/json": {
                     name: string;
                     eventId?: string;
-                    /** @enum {string} */
-                    contestType: "SINGLE_EVENT";
+                    /**
+                     * @description First-pass contest creation supports roster contests only. Future contest formats remain cataloged in the domain validity matrix.
+                     * @enum {string}
+                     */
+                    contestFormat: "ROSTER";
                     /** @enum {string} */
                     selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK";
                     /** @description Contest-configuration payload used by contest create and update endpoints. */
@@ -7892,7 +7940,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "DRAFT" | "OPEN" | "DRAFTING" | "LOCKED" | "ACTIVE" | "COMPLETED" | "CANCELLED";
                             /** @enum {string} */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /** @enum {string} */
                             selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK" | "OPEN_SELECTION" | "PICK_EM" | "BRACKET_PICK_EM";
                             /** @enum {string} */
@@ -8062,7 +8110,7 @@ export interface operations {
                 /** @description Sport to filter templates by. */
                 sport: "GOLF" | "NFL" | "NBA" | "F1" | "NASCAR" | "NCAA_BASKETBALL" | "NCAA_HOCKEY" | "NCAA_FOOTBALL" | "TENNIS" | "HORSE_RACING" | "SOCCER" | "NHL" | "MLB" | "UFC";
                 /** @description Contest type to filter templates by. */
-                contestType: "SINGLE_EVENT";
+                contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                 /** @description Optional event type used to narrow template selection. */
                 eventType?: string;
             };
@@ -8098,7 +8146,7 @@ export interface operations {
                              * @description Contest type that may use the template.
                              * @enum {string}
                              */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /**
                              * @description Configuration mode seeded by the template.
                              * @enum {string}
@@ -8290,8 +8338,11 @@ export interface operations {
                      * @description Sport-event identifier that anchors the contest.
                      */
                     sportEventId: string;
-                    /** @enum {string} */
-                    contestType: "SINGLE_EVENT";
+                    /**
+                     * @description First-pass managed contest creation supports roster contests only. The domain validity matrix catalogs future format compatibility.
+                     * @enum {string}
+                     */
+                    contestFormat: "ROSTER";
                     /** @description Approved commissioner-managed contest configuration payload for golf-first contest creation. */
                     configuration: {
                         /** @enum {string} */
@@ -8389,8 +8440,11 @@ export interface operations {
                      * @description Sport-event identifier that anchors the contest.
                      */
                     sportEventId: string;
-                    /** @enum {string} */
-                    contestType: "SINGLE_EVENT";
+                    /**
+                     * @description First-pass managed contest creation supports roster contests only. The domain validity matrix catalogs future format compatibility.
+                     * @enum {string}
+                     */
+                    contestFormat: "ROSTER";
                     /**
                      * Format: uuid
                      * @description Seeded contest template selected for the create flow.
@@ -9294,7 +9348,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "DRAFT" | "OPEN" | "DRAFTING" | "LOCKED" | "ACTIVE" | "COMPLETED" | "CANCELLED";
                             /** @enum {string} */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /** @enum {string} */
                             selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK" | "OPEN_SELECTION" | "PICK_EM" | "BRACKET_PICK_EM";
                             /** @enum {string} */
@@ -9479,7 +9533,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "DRAFT" | "OPEN" | "DRAFTING" | "LOCKED" | "ACTIVE" | "COMPLETED" | "CANCELLED";
                             /** @enum {string} */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /** @enum {string} */
                             selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK" | "OPEN_SELECTION" | "PICK_EM" | "BRACKET_PICK_EM";
                             /** @enum {string} */
@@ -9767,7 +9821,7 @@ export interface operations {
                             updatedAt: string;
                             /** @description Current picked participants for the contest entry. Omitted when picks are hidden from non-owners (contest still in DRAFT or OPEN status and viewer is not the owning squad). */
                             participants?: {
-                                rosterPickId: string;
+                                pickId: string;
                                 sportEventParticipantId: string;
                                 participantId: string;
                                 participantName: string;
@@ -9881,7 +9935,7 @@ export interface operations {
                             updatedAt: string;
                             /** @description Current picked participants for the contest entry. Omitted when picks are hidden from non-owners (contest still in DRAFT or OPEN status and viewer is not the owning squad). */
                             participants?: {
-                                rosterPickId: string;
+                                pickId: string;
                                 sportEventParticipantId: string;
                                 participantId: string;
                                 participantName: string;
@@ -10560,7 +10614,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "DRAFT" | "OPEN" | "DRAFTING" | "LOCKED" | "ACTIVE" | "COMPLETED" | "CANCELLED";
                             /** @enum {string} */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /** @enum {string} */
                             selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK" | "OPEN_SELECTION" | "PICK_EM" | "BRACKET_PICK_EM";
                             /** @enum {string} */
@@ -10719,7 +10773,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "DRAFT" | "OPEN" | "DRAFTING" | "LOCKED" | "ACTIVE" | "COMPLETED" | "CANCELLED";
                             /** @enum {string} */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /** @enum {string} */
                             selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK" | "OPEN_SELECTION" | "PICK_EM" | "BRACKET_PICK_EM";
                             /** @enum {string} */
@@ -10883,7 +10937,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "DRAFT" | "OPEN" | "DRAFTING" | "LOCKED" | "ACTIVE" | "COMPLETED" | "CANCELLED";
                             /** @enum {string} */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /** @enum {string} */
                             selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK" | "OPEN_SELECTION" | "PICK_EM" | "BRACKET_PICK_EM";
                             /** @enum {string} */
@@ -11047,7 +11101,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "DRAFT" | "OPEN" | "DRAFTING" | "LOCKED" | "ACTIVE" | "COMPLETED" | "CANCELLED";
                             /** @enum {string} */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /** @enum {string} */
                             selectionType: "SNAKE_DRAFT" | "TIERED" | "BUDGET_PICK" | "OPEN_SELECTION" | "PICK_EM" | "BRACKET_PICK_EM";
                             /** @enum {string} */
@@ -11192,24 +11246,38 @@ export interface operations {
                 content: {
                     "application/json": {
                         entries: {
+                            /** @description Audit-log entry id. */
                             id: string;
+                            /** @description League this entry belongs to. */
                             leagueId: string;
-                            contestId?: string | null;
+                            /** @description Contest this entry references when the action is contest-scoped. */
+                            contestId?: string;
+                            /** @description User id of the commissioner / actor that performed the action. */
                             actorId: string;
+                            /** @description Action verb in dotted form (e.g., "league.member.role.changed"). */
                             action: string;
-                            category: string;
+                            /**
+                             * @description Audit-log entry category — broad classification of the action that produced this entry.
+                             * @enum {string}
+                             */
+                            category: "LEAGUE" | "CONTEST" | "DRAFT" | "SCORING" | "PAYOUT" | "MEMBER" | "COMMUNICATION";
+                            /** @description Human-readable description of what happened. */
                             description: string;
+                            /** @description Opaque snapshot of relevant entity state BEFORE the action. Shape varies by category; treat as audit data, not as a typed contract. */
                             beforeState?: {
                                 [key: string]: unknown;
-                            } | null;
+                            };
+                            /** @description Opaque snapshot of relevant entity state AFTER the action. Shape varies by category; treat as audit data, not as a typed contract. */
                             afterState?: {
                                 [key: string]: unknown;
-                            } | null;
-                            reason?: string | null;
-                            ipAddress?: string | null;
+                            };
+                            /** @description Optional human-supplied reason / justification for the action. */
+                            reason?: string;
+                            /** @description IP address from which the action originated, when available. */
+                            ipAddress?: string;
                             /**
                              * Format: date-time
-                             * @description When the audit entry was created.
+                             * @description When the audit entry was recorded.
                              */
                             createdAt: string;
                         }[];
@@ -11341,10 +11409,6 @@ export interface operations {
                             participantType: "INDIVIDUAL" | "TEAM";
                             /** @description Primary provider identifier when one exists. */
                             externalId?: string;
-                            /** @description Provider-normalized metadata retained for the participant. */
-                            metadata: {
-                                [key: string]: unknown;
-                            };
                             /** @description First name when the participant is a person. */
                             firstName?: string;
                             /** @description Last name when the participant is a person. */
@@ -11434,7 +11498,6 @@ export interface operations {
                     nationality?: string;
                     position?: string;
                     teamAffiliation?: string;
-                    metadata?: Record<string, never>;
                     externalIds?: Record<string, never>;
                 };
             };
@@ -11462,10 +11525,6 @@ export interface operations {
                             participantType: "INDIVIDUAL" | "TEAM";
                             /** @description Primary provider identifier when one exists. */
                             externalId?: string;
-                            /** @description Provider-normalized metadata retained for the participant. */
-                            metadata: {
-                                [key: string]: unknown;
-                            };
                             /** @description First name when the participant is a person. */
                             firstName?: string;
                             /** @description Last name when the participant is a person. */
@@ -11565,10 +11624,6 @@ export interface operations {
                             participantType: "INDIVIDUAL" | "TEAM";
                             /** @description Primary provider identifier when one exists. */
                             externalId?: string;
-                            /** @description Provider-normalized metadata retained for the participant. */
-                            metadata: {
-                                [key: string]: unknown;
-                            };
                             /** @description First name when the participant is a person. */
                             firstName?: string;
                             /** @description Last name when the participant is a person. */
@@ -11677,7 +11732,6 @@ export interface operations {
                     status?: "ACTIVE" | "INACTIVE" | "RETIRED" | "SUSPENDED";
                     injuryStatus?: Record<string, never>;
                     photoUrl?: string;
-                    metadata?: Record<string, never>;
                     externalIds?: Record<string, never>;
                 };
             };
@@ -11705,10 +11759,6 @@ export interface operations {
                             participantType: "INDIVIDUAL" | "TEAM";
                             /** @description Primary provider identifier when one exists. */
                             externalId?: string;
-                            /** @description Provider-normalized metadata retained for the participant. */
-                            metadata: {
-                                [key: string]: unknown;
-                            };
                             /** @description First name when the participant is a person. */
                             firstName?: string;
                             /** @description Last name when the participant is a person. */
@@ -11767,209 +11817,6 @@ export interface operations {
                             /**
                              * Format: date-time
                              * @description When the participant record was last updated.
-                             */
-                            updatedAt: string;
-                        };
-                    };
-                };
-            };
-            /** @description Standard API error envelope. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @description Error payload object. */
-                        error: {
-                            /** @description Stable machine-readable error code. */
-                            code: string;
-                            /** @description Human-readable error summary safe to show to clients. */
-                            message: string;
-                            /** @description Optional structured details for client-specific handling or diagnostics. */
-                            details?: unknown;
-                        };
-                    };
-                };
-            };
-        };
-    };
-    getParticipantSeasonRecords: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Participant season-record list response. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        seasonRecords: {
-                            id: string;
-                            participantId: string;
-                            /** @enum {string} */
-                            sport: "GOLF" | "NFL" | "NBA" | "F1" | "NASCAR" | "NCAA_BASKETBALL" | "NCAA_HOCKEY" | "NCAA_FOOTBALL" | "TENNIS" | "HORSE_RACING" | "SOCCER" | "NHL" | "MLB" | "UFC";
-                            season: string;
-                            /** @description Ranking snapshots associated with the season record. */
-                            rankings: {
-                                /** @description Ranking system name, such as world ranking or tour points. */
-                                rankingType: string;
-                                /** @description Participant rank under the specified ranking system. */
-                                rank: number;
-                                /** @description Optional ranking points associated with the ranking. */
-                                points?: number;
-                                /**
-                                 * Format: date-time
-                                 * @description Date when the ranking snapshot was valid.
-                                 */
-                                asOfDate: string;
-                            }[];
-                            /** @description Current budget-draft price for the participant. */
-                            budgetPrice: number;
-                            /** @description Optional price tier label derived for the participant. */
-                            priceTier?: string;
-                            /**
-                             * Format: date-time
-                             * @description When the participant price was last refreshed.
-                             */
-                            priceUpdatedAt?: string;
-                            /** @description How many events the participant entered in the season. */
-                            eventsEntered: number;
-                            /** @description How many events the participant completed in the season. */
-                            eventsCompleted: number;
-                            /** @description Season win count. */
-                            wins: number;
-                            /** @description Top-five finish count for the season. */
-                            top5Finishes: number;
-                            /** @description Top-ten finish count for the season. */
-                            top10Finishes: number;
-                            /** @description Top-twenty-five finish count for the season. */
-                            top25Finishes: number;
-                            /** @description Provider-normalized season statistics keyed by stat name. */
-                            seasonStats: {
-                                [key: string]: number;
-                            };
-                            /** @description Derived form score used for participant valuation and sorting. */
-                            formRating: number;
-                            /**
-                             * @description Trend direction for the participant recent form.
-                             * @enum {string}
-                             */
-                            formTrend: "RISING" | "STABLE" | "FALLING";
-                            /**
-                             * Format: date-time
-                             * @description When the season record source data was last refreshed.
-                             */
-                            lastUpdated: string;
-                            /**
-                             * Format: date-time
-                             * @description When the season record was created.
-                             */
-                            createdAt: string;
-                            /**
-                             * Format: date-time
-                             * @description When the season record was last updated.
-                             */
-                            updatedAt: string;
-                        }[];
-                    };
-                };
-            };
-        };
-    };
-    getParticipantSeasonRecord: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-                season: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Single participant season-record response. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @description Participant season record used by draft-search and participant detail APIs. */
-                        seasonRecord: {
-                            id: string;
-                            participantId: string;
-                            /** @enum {string} */
-                            sport: "GOLF" | "NFL" | "NBA" | "F1" | "NASCAR" | "NCAA_BASKETBALL" | "NCAA_HOCKEY" | "NCAA_FOOTBALL" | "TENNIS" | "HORSE_RACING" | "SOCCER" | "NHL" | "MLB" | "UFC";
-                            season: string;
-                            /** @description Ranking snapshots associated with the season record. */
-                            rankings: {
-                                /** @description Ranking system name, such as world ranking or tour points. */
-                                rankingType: string;
-                                /** @description Participant rank under the specified ranking system. */
-                                rank: number;
-                                /** @description Optional ranking points associated with the ranking. */
-                                points?: number;
-                                /**
-                                 * Format: date-time
-                                 * @description Date when the ranking snapshot was valid.
-                                 */
-                                asOfDate: string;
-                            }[];
-                            /** @description Current budget-draft price for the participant. */
-                            budgetPrice: number;
-                            /** @description Optional price tier label derived for the participant. */
-                            priceTier?: string;
-                            /**
-                             * Format: date-time
-                             * @description When the participant price was last refreshed.
-                             */
-                            priceUpdatedAt?: string;
-                            /** @description How many events the participant entered in the season. */
-                            eventsEntered: number;
-                            /** @description How many events the participant completed in the season. */
-                            eventsCompleted: number;
-                            /** @description Season win count. */
-                            wins: number;
-                            /** @description Top-five finish count for the season. */
-                            top5Finishes: number;
-                            /** @description Top-ten finish count for the season. */
-                            top10Finishes: number;
-                            /** @description Top-twenty-five finish count for the season. */
-                            top25Finishes: number;
-                            /** @description Provider-normalized season statistics keyed by stat name. */
-                            seasonStats: {
-                                [key: string]: number;
-                            };
-                            /** @description Derived form score used for participant valuation and sorting. */
-                            formRating: number;
-                            /**
-                             * @description Trend direction for the participant recent form.
-                             * @enum {string}
-                             */
-                            formTrend: "RISING" | "STABLE" | "FALLING";
-                            /**
-                             * Format: date-time
-                             * @description When the season record source data was last refreshed.
-                             */
-                            lastUpdated: string;
-                            /**
-                             * Format: date-time
-                             * @description When the season record was created.
-                             */
-                            createdAt: string;
-                            /**
-                             * Format: date-time
-                             * @description When the season record was last updated.
                              */
                             updatedAt: string;
                         };
@@ -14995,7 +14842,7 @@ export interface operations {
                 /** @description Optional sport filter for root-admin contest template management. */
                 sport?: "GOLF" | "NFL" | "NBA" | "F1" | "NASCAR" | "NCAA_BASKETBALL" | "NCAA_HOCKEY" | "NCAA_FOOTBALL" | "TENNIS" | "HORSE_RACING" | "SOCCER" | "NHL" | "MLB" | "UFC";
                 /** @description Optional contest-type filter for root-admin contest template management. */
-                contestType?: "SINGLE_EVENT";
+                contestFormat?: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                 /** @description Optional active-state filter for root-admin contest template management. */
                 active?: boolean;
             };
@@ -15029,7 +14876,7 @@ export interface operations {
                              * @description Contest type that may use the template.
                              * @enum {string}
                              */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /**
                              * @description Configuration mode seeded by the template.
                              * @enum {string}
@@ -15304,7 +15151,7 @@ export interface operations {
                              * @description Contest type that may use the template.
                              * @enum {string}
                              */
-                            contestType: "SINGLE_EVENT";
+                            contestFormat: "ROSTER" | "BRACKET" | "PICKEM_CONFIDENCE" | "SURVIVOR" | "PREDICT_TOP_N";
                             /**
                              * @description Configuration mode seeded by the template.
                              * @enum {string}
@@ -20571,6 +20418,25 @@ export interface operations {
                 };
             };
             /** @description Standard API error envelope. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -21047,6 +20913,44 @@ export interface operations {
                 };
             };
             /** @description Standard API error envelope. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -21134,6 +21038,44 @@ export interface operations {
                 };
             };
             /** @description Standard API error envelope. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -21209,6 +21151,44 @@ export interface operations {
                             errorLog: {
                                 [key: string]: unknown;
                             }[];
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
                         };
                     };
                 };
@@ -21294,6 +21274,44 @@ export interface operations {
                 };
             };
             /** @description Standard API error envelope. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -21343,6 +21361,44 @@ export interface operations {
                         odds: {
                             [key: string]: unknown;
                         }[];
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Standard API error envelope. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Error payload object. */
+                        error: {
+                            /** @description Stable machine-readable error code. */
+                            code: string;
+                            /** @description Human-readable error summary safe to show to clients. */
+                            message: string;
+                            /** @description Optional structured details for client-specific handling or diagnostics. */
+                            details?: unknown;
+                        };
                     };
                 };
             };

--- a/scripts/check-openapi-fresh.mjs
+++ b/scripts/check-openapi-fresh.mjs
@@ -106,6 +106,9 @@ try {
 
   run('npx', ['@hey-api/openapi-ts', '-f', tempConfig]);
 
+  const tempApiTypes = join(tempRoot, 'api-types.ts');
+  run('npx', ['openapi-typescript', tempOpenApi, '-o', tempApiTypes]);
+
   const differences = [];
   compareFile(
     resolve(root, 'packages/shared/generated/openapi.json'),
@@ -117,6 +120,12 @@ try {
     resolve(root, 'packages/shared/generated/hey-api'),
     tempGenerated,
     'hey-api client',
+    differences,
+  );
+  compareFile(
+    resolve(root, 'packages/shared/generated/api-types.ts'),
+    tempApiTypes,
+    'api-types.ts',
     differences,
   );
 

--- a/tests/integration/core-api/contest-entry-pick-contest-format-invariant.integration.ts
+++ b/tests/integration/core-api/contest-entry-pick-contest-format-invariant.integration.ts
@@ -1,0 +1,191 @@
+/**
+ * Contract coverage for the ContestEntryPick.contestFormat denormalization
+ * invariant from plans/117 §7.1: every persisted pick row's `contestFormat`
+ * column matches the parent `Contest.contestFormat`.
+ *
+ * The denormalization makes the per-format partial unique indexes (see
+ * `contest-entry-pick-partial-uniques.integration.ts`) implementable —
+ * Postgres partial indexes can predicate only on local columns. For that to
+ * be safe the application layer must guarantee the denormalized column never
+ * drifts from the parent contest.
+ *
+ * pool-master-rop.78.6 — service-layer enforcement of this invariant lives
+ * in `ContestEntryPickService.createPick`. This test exercises the service
+ * end-to-end and asserts the database row matches the parent contest. It
+ * also asserts a global cross-row invariant (`pick.contestFormat ===
+ * pick.entry.contest.contestFormat`) over every persisted pick at the end
+ * of the suite — a defensive check against any future code path that might
+ * bypass the service.
+ */
+import { randomUUID } from 'node:crypto';
+import {
+  cleanupTestData,
+  getPrisma,
+  setupIntegrationTests,
+  teardownIntegrationTests,
+} from '../helpers';
+import { ParticipantType, Sport } from '@poolmaster/shared/domain';
+import {
+  ContestEntryPickService,
+} from '../../../packages/core-api/src/modules/contest-entry-picks';
+
+beforeAll(() => setupIntegrationTests());
+afterAll(async () => {
+  await cleanupTestData();
+  await teardownIntegrationTests();
+});
+
+interface FormatFixture {
+  contestId: string;
+  entryId: string;
+  sportEventParticipantId: string;
+}
+
+async function seedFixtureForFormat(contestFormat: string): Promise<FormatFixture> {
+  const prisma = getPrisma();
+  const suffix = randomUUID().slice(0, 8);
+
+  const user = await prisma.user.create({
+    data: {
+      email: `pick-invariant-${suffix}@example.com`,
+      username: `pick-invariant-${suffix}`,
+      firstName: 'Invariant',
+      lastName: 'Pick',
+      isActive: true,
+    },
+  });
+  const league = await prisma.league.create({
+    data: {
+      leagueCode: `PIN${suffix.toUpperCase()}`,
+      name: `Invariant League ${suffix}`,
+      createdBy: user.id,
+      iconKey: 'TROPHY',
+      joinPolicy: 'COMMISSIONER_ONLY',
+    },
+  });
+  await prisma.leagueMembership.create({
+    data: {
+      leagueId: league.id,
+      userId: user.id,
+      role: 'COMMISSIONER',
+      status: 'ACTIVE',
+      joinedAt: new Date(),
+    },
+  });
+  const squad = await prisma.squad.create({
+    data: {
+      leagueId: league.id,
+      name: `Invariant Squad ${suffix}`,
+      createdBy: user.id,
+    },
+  });
+
+  const sport = await prisma.sport.create({
+    data: {
+      name: `Invariant Sport ${suffix}`,
+      participantType: ParticipantType.INDIVIDUAL,
+    },
+  });
+  const sportEvent = await prisma.sportEvent.create({
+    data: {
+      externalId: `pick-invariant-${suffix}`,
+      providerId: 'integration-test',
+      sport: Sport.GOLF,
+      name: `Invariant Event ${suffix}`,
+      startDate: new Date('2030-01-01T12:00:00.000Z'),
+      releaseAt: new Date('2030-01-01T12:00:00.000Z'),
+      fieldLocksAt: new Date('2030-01-15T12:00:00.000Z'),
+      status: 'SCHEDULED',
+    },
+  });
+  const participant = await prisma.participant.create({
+    data: {
+      sportId: sport.id,
+      name: `Invariant Participant ${suffix}`,
+      participantType: ParticipantType.INDIVIDUAL,
+      externalIds: {},
+    },
+  });
+  const sep = await prisma.sportEventParticipant.create({
+    data: {
+      sportEventId: sportEvent.id,
+      participantId: participant.id,
+      status: 'ACTIVE',
+    },
+  });
+  const contest = await prisma.contest.create({
+    data: {
+      leagueId: league.id,
+      sportEventId: sportEvent.id,
+      name: `Invariant Contest ${suffix}`,
+      status: 'OPEN',
+      contestFormat: contestFormat as 'ROSTER',
+      selectionType: 'TIERED',
+      scoringEngine: 'STROKE_PLAY',
+    },
+  });
+  const entry = await prisma.contestEntry.create({
+    data: {
+      contestId: contest.id,
+      squadId: squad.id,
+      entryNumber: 1,
+      name: `Invariant Entry ${suffix}`,
+      status: 'ACTIVE',
+    },
+  });
+
+  return {
+    contestId: contest.id,
+    entryId: entry.id,
+    sportEventParticipantId: sep.id,
+  };
+}
+
+describe('plans/117 §7.1 — ContestEntryPick.contestFormat denormalization invariant', () => {
+  it('reads the parent contest format and writes it onto the pick row regardless of caller intent', async () => {
+    const prisma = getPrisma();
+    const service = new ContestEntryPickService(prisma);
+
+    for (const format of ['ROSTER', 'BRACKET', 'PICKEM_CONFIDENCE', 'PREDICT_TOP_N', 'SURVIVOR']) {
+      const fixture = await seedFixtureForFormat(format);
+      const dto = await service.createPick({
+        entryId: fixture.entryId,
+        sportEventParticipantId: fixture.sportEventParticipantId,
+        // Per-format metadata varies; supply the minimum each partial index
+        // expects so the row can be inserted without violating uniqueness.
+        period: format === 'BRACKET' || format === 'PICKEM_CONFIDENCE' || format === 'SURVIVOR' ? 1 : null,
+        slot: format === 'BRACKET' || format === 'PICKEM_CONFIDENCE' || format === 'PREDICT_TOP_N' ? 1 : null,
+      });
+
+      expect(dto.contestFormat).toBe(format);
+      const row = await prisma.contestEntryPick.findUniqueOrThrow({
+        where: { id: dto.id },
+      });
+      expect(row.contestFormat).toBe(format);
+
+      // Cross-check: pick.contestFormat === parent contest.contestFormat.
+      const parentContest = await prisma.contest.findUniqueOrThrow({
+        where: { id: fixture.contestId },
+        select: { contestFormat: true },
+      });
+      expect(row.contestFormat).toBe(parentContest.contestFormat);
+    }
+  });
+
+  it('global invariant — every persisted pick has contestFormat matching its parent contest', async () => {
+    const prisma = getPrisma();
+    const drifted = await prisma.contestEntryPick.findMany({
+      include: {
+        entry: {
+          include: {
+            contest: { select: { contestFormat: true } },
+          },
+        },
+      },
+    });
+    const violations = drifted.filter(
+      (pick) => pick.contestFormat !== pick.entry.contest.contestFormat,
+    );
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/integration/core-api/contest-entry-pick-contest-format-invariant.integration.ts
+++ b/tests/integration/core-api/contest-entry-pick-contest-format-invariant.integration.ts
@@ -141,7 +141,7 @@ async function seedFixtureForFormat(contestFormat: string): Promise<FormatFixtur
   };
 }
 
-describe('plans/117 §7.1 — ContestEntryPick.contestFormat denormalization invariant', () => {
+describe('pool-master-rop.78.6 / plans/117 §7.1 — ContestEntryPick.contestFormat denormalization invariant', () => {
   it('reads the parent contest format and writes it onto the pick row regardless of caller intent', async () => {
     const prisma = getPrisma();
     const service = new ContestEntryPickService(prisma);

--- a/tests/integration/core-api/contest-entry-pick-partial-uniques.integration.ts
+++ b/tests/integration/core-api/contest-entry-pick-partial-uniques.integration.ts
@@ -166,7 +166,7 @@ async function seedContestFixture(contestFormat: string): Promise<FixtureContext
   };
 }
 
-describe('plans/117 §7.1 — ContestEntryPick partial unique indexes', () => {
+describe('pool-master-rop.78.6 / plans/117 §7.1 — ContestEntryPick partial unique indexes', () => {
   it('uq_pick_roster_participant — rejects duplicate ROSTER picks for the same sport-event participant on one entry', async () => {
     const prisma = getPrisma();
     const fixture = await seedContestFixture('ROSTER');

--- a/tests/integration/core-api/contest-entry-pick-partial-uniques.integration.ts
+++ b/tests/integration/core-api/contest-entry-pick-partial-uniques.integration.ts
@@ -1,0 +1,335 @@
+/**
+ * Integration coverage for the per-contest-format partial unique indexes
+ * landed by pool-master-rop.78.4 (plans/117 §7.1).
+ *
+ * Each `contest_entry_picks` partial unique enforces a per-format pick rule
+ * that only Postgres-level constraints can guarantee under load. This suite
+ * builds a real entry, inserts a valid pick for each format, then asserts
+ * the duplicate insert fails with Prisma's P2002 unique-violation code.
+ *
+ * Indexes asserted:
+ *   - uq_pick_roster_participant — ROSTER: no double-picking same participant
+ *   - uq_pick_period_slot — BRACKET / PICKEM_CONFIDENCE: no duplicate
+ *     (period, slot) tuple
+ *   - uq_pick_predicted_position — PREDICT_TOP_N: no duplicate slot
+ *   - uq_pick_survivor_week — SURVIVOR: one pick per week (period) per entry
+ *
+ * pool-master-rop.78.6 — service-layer enforcement of the contestFormat
+ * denormalization invariant is the second half of the guarantee; that layer
+ * is asserted in `contest-entry-pick-contest-format-invariant.integration.ts`.
+ */
+import { randomUUID } from 'node:crypto';
+import {
+  cleanupTestData,
+  getPrisma,
+  setupIntegrationTests,
+  teardownIntegrationTests,
+} from '../helpers';
+import { ParticipantType, Sport } from '@poolmaster/shared/domain';
+
+beforeAll(() => setupIntegrationTests());
+afterAll(async () => {
+  await cleanupTestData();
+  await teardownIntegrationTests();
+});
+
+interface FixtureContext {
+  contestId: string;
+  entryId: string;
+  participantAId: string;
+  participantBId: string;
+}
+
+async function seedContestFixture(contestFormat: string): Promise<FixtureContext> {
+  const prisma = getPrisma();
+  const suffix = randomUUID().slice(0, 8);
+
+  // Owning user, league, squad — enough scaffolding for a real ContestEntry.
+  const user = await prisma.user.create({
+    data: {
+      email: `partial-uniques-${suffix}@example.com`,
+      username: `partial-uniques-${suffix}`,
+      firstName: 'Partial',
+      lastName: 'Uniques',
+      isActive: true,
+    },
+  });
+  const league = await prisma.league.create({
+    data: {
+      leagueCode: `PUL${suffix.toUpperCase()}`,
+      name: `Partial Uniques League ${suffix}`,
+      createdBy: user.id,
+      iconKey: 'TROPHY',
+      joinPolicy: 'COMMISSIONER_ONLY',
+    },
+  });
+  await prisma.leagueMembership.create({
+    data: {
+      leagueId: league.id,
+      userId: user.id,
+      role: 'COMMISSIONER',
+      status: 'ACTIVE',
+      joinedAt: new Date(),
+    },
+  });
+  const squad = await prisma.squad.create({
+    data: {
+      leagueId: league.id,
+      name: `Partial Uniques Squad ${suffix}`,
+      createdBy: user.id,
+    },
+  });
+  await prisma.squadMembership.create({
+    data: {
+      squadId: squad.id,
+      userId: user.id,
+      status: 'ACTIVE',
+      leagueId: league.id,
+      joinedAt: new Date(),
+    },
+  });
+
+  const sport = await prisma.sport.create({
+    data: {
+      name: `Partial Uniques Sport ${suffix}`,
+      participantType: ParticipantType.INDIVIDUAL,
+    },
+  });
+  const sportEvent = await prisma.sportEvent.create({
+    data: {
+      externalId: `partial-uniques-${suffix}`,
+      providerId: 'integration-test',
+      sport: Sport.GOLF,
+      name: `Partial Uniques Event ${suffix}`,
+      startDate: new Date('2030-01-01T12:00:00.000Z'),
+      releaseAt: new Date('2030-01-01T12:00:00.000Z'),
+      fieldLocksAt: new Date('2030-01-15T12:00:00.000Z'),
+      status: 'SCHEDULED',
+    },
+  });
+  const participantA = await prisma.participant.create({
+    data: {
+      sportId: sport.id,
+      name: `Participant A ${suffix}`,
+      participantType: ParticipantType.INDIVIDUAL,
+      externalIds: {},
+    },
+  });
+  const participantB = await prisma.participant.create({
+    data: {
+      sportId: sport.id,
+      name: `Participant B ${suffix}`,
+      participantType: ParticipantType.INDIVIDUAL,
+      externalIds: {},
+    },
+  });
+  const sepA = await prisma.sportEventParticipant.create({
+    data: {
+      sportEventId: sportEvent.id,
+      participantId: participantA.id,
+      status: 'ACTIVE',
+    },
+  });
+  const sepB = await prisma.sportEventParticipant.create({
+    data: {
+      sportEventId: sportEvent.id,
+      participantId: participantB.id,
+      status: 'ACTIVE',
+    },
+  });
+  const contest = await prisma.contest.create({
+    data: {
+      leagueId: league.id,
+      sportEventId: sportEvent.id,
+      name: `Partial Uniques Contest ${suffix}`,
+      status: 'OPEN',
+      contestFormat: contestFormat as 'ROSTER',
+      selectionType: 'TIERED',
+      scoringEngine: 'STROKE_PLAY',
+    },
+  });
+  const entry = await prisma.contestEntry.create({
+    data: {
+      contestId: contest.id,
+      squadId: squad.id,
+      entryNumber: 1,
+      name: `Entry ${suffix}`,
+      status: 'ACTIVE',
+    },
+  });
+
+  return {
+    contestId: contest.id,
+    entryId: entry.id,
+    participantAId: sepA.id,
+    participantBId: sepB.id,
+  };
+}
+
+describe('plans/117 §7.1 — ContestEntryPick partial unique indexes', () => {
+  it('uq_pick_roster_participant — rejects duplicate ROSTER picks for the same sport-event participant on one entry', async () => {
+    const prisma = getPrisma();
+    const fixture = await seedContestFixture('ROSTER');
+
+    await prisma.contestEntryPick.create({
+      data: {
+        entryId: fixture.entryId,
+        sportEventParticipantId: fixture.participantAId,
+        contestFormat: 'ROSTER',
+        isAutoPicked: false,
+      },
+    });
+
+    await expect(
+      prisma.contestEntryPick.create({
+        data: {
+          entryId: fixture.entryId,
+          sportEventParticipantId: fixture.participantAId,
+          contestFormat: 'ROSTER',
+          isAutoPicked: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'P2002' });
+
+    // Different sport-event participant succeeds — the partial index is
+    // scoped to (entry, sportEventParticipantId).
+    await prisma.contestEntryPick.create({
+      data: {
+        entryId: fixture.entryId,
+        sportEventParticipantId: fixture.participantBId,
+        contestFormat: 'ROSTER',
+        isAutoPicked: false,
+      },
+    });
+  });
+
+  it('uq_pick_period_slot — rejects duplicate (entry, period, slot) tuples for BRACKET / PICKEM_CONFIDENCE', async () => {
+    const prisma = getPrisma();
+    const bracketFixture = await seedContestFixture('BRACKET');
+
+    await prisma.contestEntryPick.create({
+      data: {
+        entryId: bracketFixture.entryId,
+        sportEventParticipantId: bracketFixture.participantAId,
+        contestFormat: 'BRACKET',
+        period: 1,
+        slot: 1,
+        isAutoPicked: false,
+      },
+    });
+
+    await expect(
+      prisma.contestEntryPick.create({
+        data: {
+          entryId: bracketFixture.entryId,
+          sportEventParticipantId: bracketFixture.participantBId,
+          contestFormat: 'BRACKET',
+          period: 1,
+          slot: 1,
+          isAutoPicked: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'P2002' });
+
+    // The same partial index also applies to PICKEM_CONFIDENCE.
+    const pickemFixture = await seedContestFixture('PICKEM_CONFIDENCE');
+    await prisma.contestEntryPick.create({
+      data: {
+        entryId: pickemFixture.entryId,
+        sportEventParticipantId: pickemFixture.participantAId,
+        contestFormat: 'PICKEM_CONFIDENCE',
+        period: 5,
+        slot: 16,
+        isAutoPicked: false,
+      },
+    });
+    await expect(
+      prisma.contestEntryPick.create({
+        data: {
+          entryId: pickemFixture.entryId,
+          sportEventParticipantId: pickemFixture.participantBId,
+          contestFormat: 'PICKEM_CONFIDENCE',
+          period: 5,
+          slot: 16,
+          isAutoPicked: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'P2002' });
+  });
+
+  it('uq_pick_predicted_position — rejects duplicate slot picks for PREDICT_TOP_N', async () => {
+    const prisma = getPrisma();
+    const fixture = await seedContestFixture('PREDICT_TOP_N');
+
+    await prisma.contestEntryPick.create({
+      data: {
+        entryId: fixture.entryId,
+        sportEventParticipantId: fixture.participantAId,
+        contestFormat: 'PREDICT_TOP_N',
+        slot: 1,
+        isAutoPicked: false,
+      },
+    });
+
+    await expect(
+      prisma.contestEntryPick.create({
+        data: {
+          entryId: fixture.entryId,
+          sportEventParticipantId: fixture.participantBId,
+          contestFormat: 'PREDICT_TOP_N',
+          slot: 1,
+          isAutoPicked: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'P2002' });
+
+    // A different predicted position succeeds.
+    await prisma.contestEntryPick.create({
+      data: {
+        entryId: fixture.entryId,
+        sportEventParticipantId: fixture.participantBId,
+        contestFormat: 'PREDICT_TOP_N',
+        slot: 2,
+        isAutoPicked: false,
+      },
+    });
+  });
+
+  it('uq_pick_survivor_week — rejects more than one SURVIVOR pick per (entry, period)', async () => {
+    const prisma = getPrisma();
+    const fixture = await seedContestFixture('SURVIVOR');
+
+    await prisma.contestEntryPick.create({
+      data: {
+        entryId: fixture.entryId,
+        sportEventParticipantId: fixture.participantAId,
+        contestFormat: 'SURVIVOR',
+        period: 1,
+        isAutoPicked: false,
+      },
+    });
+
+    await expect(
+      prisma.contestEntryPick.create({
+        data: {
+          entryId: fixture.entryId,
+          sportEventParticipantId: fixture.participantBId,
+          contestFormat: 'SURVIVOR',
+          period: 1,
+          isAutoPicked: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'P2002' });
+
+    // Different week succeeds.
+    await prisma.contestEntryPick.create({
+      data: {
+        entryId: fixture.entryId,
+        sportEventParticipantId: fixture.participantBId,
+        contestFormat: 'SURVIVOR',
+        period: 2,
+        isAutoPicked: false,
+      },
+    });
+  });
+});

--- a/tests/integration/core-api/roster-pick-crud.integration.ts
+++ b/tests/integration/core-api/roster-pick-crud.integration.ts
@@ -156,7 +156,7 @@ describe('RosterPick CRUD integration', () => {
         draftPickNumber: 1,
         pickedAt: new Date('2026-04-10T12:05:00.000Z'),
         contestFormat: 'ROSTER',
-      isAutoPicked: false,
+        isAutoPicked: false,
       },
     });
 
@@ -192,7 +192,7 @@ describe('RosterPick CRUD integration', () => {
           draftPickNumber: 4,
           pickedAt: new Date('2026-04-10T12:06:00.000Z'),
           contestFormat: 'ROSTER',
-      isAutoPicked: false,
+        isAutoPicked: false,
         },
       }),
     ).rejects.toMatchObject({

--- a/tests/unit/shared/contest-entry-pick-canonical-shape.test.ts
+++ b/tests/unit/shared/contest-entry-pick-canonical-shape.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Defect-proof structural assertions for pool-master-rop.78.6 — contest-entry
+ * pick unification.
+ *
+ * These tests fail against origin/main (where the dual RosterPick/EntryPick
+ * shapes co-existed and the shared port advertised a caller-supplied
+ * `ContestEntryPickRepository.create` write path) and pass on this branch
+ * after unification. They are the failing-test-before-fix proof that the
+ * substrate now has exactly one canonical pick shape and exactly one write
+ * path.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import * as sharedDto from '@poolmaster/shared/dto';
+
+describe('pool-master-rop.78.6 — ContestEntryPick canonical shape', () => {
+  it('exposes ContestEntryPickDtoSchema as the canonical raw-row DTO', () => {
+    expect(sharedDto).toHaveProperty('ContestEntryPickDtoSchema');
+  });
+
+  it('uses pickId (not rosterPickId) on the participant detail shape', () => {
+    const shape = sharedDto.ContestEntryParticipantDetailDtoSchema.shape;
+    expect(shape).toHaveProperty('pickId');
+    expect(shape).not.toHaveProperty('rosterPickId');
+  });
+
+  it('does not re-export the dropped RosterPickDto symbol', () => {
+    expect(sharedDto).not.toHaveProperty('RosterPickDto');
+    expect(sharedDto).not.toHaveProperty('RosterPickDtoSchema');
+  });
+
+  it('does not advertise a caller-supplied ContestEntryPickRepository write port', () => {
+    // Type-only export: read source so the assertion fires at unit-test time
+    // rather than relying on tsc to catch a missing port (which would only
+    // surface if some caller still depended on the dropped interface).
+    const portsSrc = readFileSync(
+      resolve(__dirname, '../../../packages/shared/db/ports.ts'),
+      'utf8',
+    );
+    expect(portsSrc).not.toMatch(/ContestEntryPickRepository/);
+  });
+
+  it('does not contain rosterPickId in the generated OpenAPI types', () => {
+    const apiTypesSrc = readFileSync(
+      resolve(__dirname, '../../../packages/shared/generated/api-types.ts'),
+      'utf8',
+    );
+    expect(apiTypesSrc).not.toMatch(/rosterPickId/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 entry-pick unification slice for \`pool-master-rop.78\` per [plans/117 §4.3, §7.1, §12.1](../blob/main/plans/117-league-contest-substrate-redesign.md). Lands the canonical \`ContestEntryPickDtoSchema\`, its mapper, and the \`ContestEntryPickService\` that enforces the \`contestFormat\` denormalization invariant at the single insert path. Adds integration coverage for the four §7.1 partial unique indexes and a contract test for the per-pick \`contestFormat === parent contest.contestFormat\` invariant.

The existing snake-draft route in \`drafts/routes.ts\` now goes through \`ContestEntryPickService.createPick\` instead of hardcoding \`contestFormat: 'ROSTER'\`. Future contest-format work (BRACKET, PICKEM_CONFIDENCE, etc.) plugs into the same service.

This unblocks \`rop.78.7\` (golf-roster contribution + scoring rule), which needs the typed pick mapper to score against unified pick rows.

## Files

- \`packages/shared/dto/contests.dto.ts\` — \`ContestEntryPickDtoSchema\`
- \`packages/core-api/src/mappers/contest-entry-picks.mapper.ts\` — row → DTO + row → domain
- \`packages/core-api/src/modules/contest-entry-picks/{service,types,index}.ts\` — \`ContestEntryPickService\`
- \`packages/core-api/src/modules/drafts/routes.ts\` — wired to the new service
- \`tests/integration/core-api/contest-entry-pick-partial-uniques.integration.ts\` — 4 partial-unique tests
- \`tests/integration/core-api/contest-entry-pick-contest-format-invariant.integration.ts\` — contract test

## Test plan

- [x] \`npx turbo typecheck --force\` — 5/5 clean
- [x] \`npm run rules:check\` — clean
- [x] \`npx eslint 'packages/*/src/**/*.ts' 'clients/*/src/**/*.{ts,tsx}' --max-warnings 0\` — clean
- [x] \`npm run api:check\` — generated SDK fresh (now also diffs \`api-types.ts\`)
- [x] \`npx jest --config tests/jest.config.js --forceExit\` — 597 passed, 1 skipped (rop.78.7)
- [x] \`npm run test:integration\` — 56 passed, 2 skipped (rop.78.5 / rop.78.7); 6 new tests added in this slice
- [x] \`npm run test:service:functional-api\` — 60 passed
- [ ] CI runs \`test:coverage:service:merged\` on a fresh DB

## Pass 2 response (Codex review · 2026-05-07)

Addresses three findings from the Codex Pass 2 cross-model review at [#25 comment 4399222576](https://github.com/derek-dorazio/pool-master/pull/25#issuecomment-4399222576):

- **HIGH/CONTRACT — generated \`rosterPickId\` field:** regenerated \`packages/shared/generated/api-types.ts\` from the fresh \`openapi.json\`. The committed \`participants\` shape now advertises \`pickId\` only. Root-cause fix: wired \`openapi-typescript\` into \`npm run api:generate\` and extended \`scripts/check-openapi-fresh.mjs\` so \`api-types.ts\` is diffed against a temp regen on every CI run — this artifact can no longer drift silently.
- **HIGH/TEST — defect-proof reproduction:** added \`tests/unit/shared/contest-entry-pick-canonical-shape.test.ts\`. Five structural assertions; **3 of 5 fail against \`origin/main\`** (\`ContestEntryPickDtoSchema\` missing, \`ContestEntryPickRepository\` port present, \`rosterPickId\` in api-types) and **all 5 pass on this branch**. Failing-test-before-fix run on \`origin/main\` (HEAD 86595f54):
  ```
  FAIL tests/unit/shared/contest-entry-pick-canonical-shape.test.ts
    ● exposes ContestEntryPickDtoSchema as the canonical raw-row DTO
    ● does not advertise a caller-supplied ContestEntryPickRepository write port
    ● does not contain rosterPickId in the generated OpenAPI types
  Tests: 3 failed, 2 passed, 5 total
  ```
- **MEDIUM/ARCH — phantom \`ContestEntryPickRepository\` port:** removed the unused interface from \`packages/shared/db/ports.ts\` and its barrel export from \`packages/shared/db/index.ts\`. The shared port surface no longer advertises a caller-supplied \`create(...)\` write path that bypasses \`ContestEntryPickService\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Riley findings

<!-- riley:findings -->

| Severity | Category | Finding | Location |
|---|---|---|---|
| MEDIUM | CONTRACT | \`ContestEntryPickDtoSchema\` fields \`period\`, \`slot\`, \`tier\`, \`cost\`, \`draftRound\`, \`draftPickNumber\` are typed \`nullable()\` (required field, value is null) while the domain interface declares them optional (\`period?: number\`). The mapper correctly converts null→undefined for the domain path. Divergence is intentional by the plan (DTO = null; domain = optional) but worth noting as a source of future confusion if consumers treat DTO null as domain undefined. No action required; track if the domain interface should align. | \`packages/shared/dto/contests.dto.ts\` lines 230–242; \`packages/shared/domain/types.ts\` line 276 |
| MEDIUM | TEST | Both new integration test files use \`plans/117 §7.1\` as the traceability reference in describe-block names. \`testing-rules.md §1A\` enumerates UC-IDs, BR-IDs, defect IDs, or rule-pattern references (for infrastructure-only tests) as accepted forms. Plan references are not enumerated. These are schema-constraint (infrastructure-only) tests, so the rule-reference fallback applies — but the reference target (\`plans/117\`) is a slice-life plan file, not a permanent rule. Consider adding a BR-ID for the denormalization invariant if one exists, or accept the plan reference as the closest available anchor and note it as a follow-up for rop.78 closeout. | \`tests/integration/core-api/contest-entry-pick-partial-uniques.integration.ts\` line 169; \`tests/integration/core-api/contest-entry-pick-contest-format-invariant.integration.ts\` line 144 |
| LOW | ARCH | \`ContestEntryPickService\` is instantiated inline per-request (\`new ContestEntryPickService(prisma, fastify.log)\` at line 1175) rather than once per Fastify module. Inconsistent with how other services are registered in core-api. No correctness impact. | \`packages/core-api/src/modules/drafts/routes.ts\` line 1175 |

**No CRITICAL or HIGH findings. Zero stale \`prisma.contestEntryPick.create\` bypass paths in production code. Transaction scoping is correct. All four §7.1 partial-unique indexes are covered with both positive (different value succeeds) and negative (duplicate rejected with P2002) assertions. Denormalization invariant is correctly enforced: caller cannot supply \`contestFormat\`; service resolves it from the parent contest inside the transaction.**

**Recommendation: APPROVE — eligible for auto-merge per pass-1 gate (zero CRITICAL/HIGH).**
