### PR TITLE
[pool-master-rop.78.7] Golf-roster contribution + scoring rule + live-score consumer

### DIFF
--- a/packages/core-api/src/index.ts
+++ b/packages/core-api/src/index.ts
@@ -45,6 +45,7 @@ import { StandingsRollup } from './modules/scoring/rollup/standings-rollup';
 import { ScoringService } from './modules/scoring/service';
 import { scoringRoutes } from './modules/scoring/routes';
 import { ContestScoringRecalculationService } from './modules/contest-scoring';
+import { LiveScoreConsumer } from './modules/scoring/consumer/live-score-consumer';
 
 // Notification module
 import { notificationsModule } from './modules/notifications/routes';
@@ -92,13 +93,21 @@ export function buildApp() {
 
   // --- Scoring subsystem (Prisma-backed) ---
   // pool-master-rop.78.3 — the legacy ContestLookup + stat-event consumer
-  // path was retired with the ProviderStatEvent contract. The new
-  // live_score.persisted consumer lands in rop.78.7 atop the typed
-  // SportEventParticipantGolfRound substrate.
+  // path was retired with the ProviderStatEvent contract.
+  // pool-master-rop.78.7 — the typed live_score.persisted consumer is
+  // wired below; it dispatches to per-(category × contestFormat) scoring
+  // functions (Phase 4 ships golf-roster only) and reranks via the
+  // existing standingsRollup.
   const standingsRollup = new StandingsRollup({ eventBus, prisma, logger: app.log });
   const scoringService = new ScoringService({ standingsRollup, prisma, logger: app.log });
   const contestScoringRecalculationService = new ContestScoringRecalculationService(prisma, app.log);
   void contestScoringRecalculationService;
+  const liveScoreConsumer = new LiveScoreConsumer({
+    prisma,
+    eventBus,
+    standingsRollup,
+    logger: app.log,
+  });
 
   // =========================================================================
   // Core plugins
@@ -243,10 +252,15 @@ export function buildApp() {
   // =========================================================================
   app.register(scoringRoutes, { prefix: '/api/v1', scoringService });
 
-  // pool-master-rop.78.3 — stat-event consumer subscription removed; the
-  // live_score.persisted consumer lands in rop.78.7. Periodic standings
-  // rollup continues to run.
+  // pool-master-rop.78.7 — typed live_score.persisted consumer subscribed
+  // here. It dispatches per (event.category × pick.contestFormat) and runs
+  // the scoring → contributions → totalScore → rerank pipeline under a
+  // per-contest advisory lock (plans/117 §11.3, §11.4, §11.5).
+  // Periodic standings rollup continues to run as a defensive backstop;
+  // rop.78.8 will retire it once the event-driven path is the canonical
+  // single write path.
   if (!isOpenApiExport) {
+    liveScoreConsumer.subscribe();
     standingsRollup.startPeriodicRollup();
   }
 

--- a/packages/core-api/src/mappers/contest-entry-pick-golf-roster-contributions.mapper.ts
+++ b/packages/core-api/src/mappers/contest-entry-pick-golf-roster-contributions.mapper.ts
@@ -1,0 +1,55 @@
+/**
+ * ContestEntryPickGolfRosterContribution mapper — Prisma row →
+ * ContestEntryPickGolfRosterContributionDto per plans/117 §8.1.
+ *
+ * Pure projection. The `contribution` column arrives as a Prisma Decimal
+ * (Decimal(12, 4)); the only transformation is JSON-serializable coercion
+ * to a plain number.
+ */
+
+import type { ContestEntryPickGolfRosterContributionDto } from '@poolmaster/shared/dto';
+
+interface DecimalLike {
+  toNumber(): number;
+}
+
+function isDecimalLike(value: unknown): value is DecimalLike {
+  return typeof value === 'object' && value !== null && typeof (value as DecimalLike).toNumber === 'function';
+}
+
+export interface ContestEntryPickGolfRosterContributionRow {
+  id: string;
+  contestEntryPickId: string;
+  round: number;
+  strokes: number;
+  scoreToPar: number;
+  contribution: DecimalLike | number;
+  contributedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export function mapContestEntryPickGolfRosterContributionToDto(
+  row: ContestEntryPickGolfRosterContributionRow,
+): ContestEntryPickGolfRosterContributionDto {
+  let contribution: number;
+  if (typeof row.contribution === 'number') {
+    contribution = row.contribution;
+  } else if (isDecimalLike(row.contribution)) {
+    contribution = row.contribution.toNumber();
+  } else {
+    contribution = Number(row.contribution);
+  }
+
+  return {
+    id: row.id,
+    contestEntryPickId: row.contestEntryPickId,
+    round: row.round,
+    strokes: row.strokes,
+    scoreToPar: row.scoreToPar,
+    contribution,
+    contributedAt: row.contributedAt.toISOString(),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}

--- a/packages/core-api/src/modules/scoring/consumer/live-score-consumer.ts
+++ b/packages/core-api/src/modules/scoring/consumer/live-score-consumer.ts
@@ -185,6 +185,20 @@ export class LiveScoreConsumer {
           rules: config,
         });
 
+        // Delete contribution rows for this pick whose round is no longer
+        // in the computed contribution set. A previously COMPLETED round
+        // can be corrected to DNF / DSQ / PENDING (status filter drops it),
+        // or a TOP_N_BEST / SPECIFIC_ROUNDS rule can stop selecting it
+        // after a correction. Without this delete, the totalScore aggregate
+        // below would still sum the stale row.
+        const liveRounds = contributions.map((c) => c.round);
+        await tx.contestEntryPickGolfRosterContribution.deleteMany({
+          where: {
+            contestEntryPickId: pick.id,
+            ...(liveRounds.length > 0 ? { round: { notIn: liveRounds } } : {}),
+          },
+        });
+
         for (const contribution of contributions) {
           await tx.contestEntryPickGolfRosterContribution.upsert({
             where: {
@@ -245,7 +259,13 @@ export class LiveScoreConsumer {
       // Rerank + emit standings.updated outside the scoring transaction so
       // the rollup uses the freshly committed totalScore values and so a
       // rerank failure doesn't roll back the contribution writes.
-      await this.standingsRollup.rollupContest(contestId);
+      // Golf-roster ranks lower-is-better: an entry at -5 (under par) wins
+      // over an entry at +2. The rollup defaults to higher-is-better for
+      // the rest of the pool formats (BRACKET / PICKEM_CONFIDENCE /
+      // SURVIVOR / future basketball-roster / etc.).
+      await this.standingsRollup.rollupContest(contestId, {
+        rankDirection: 'LOWER_IS_BETTER',
+      });
     }
   }
 }

--- a/packages/core-api/src/modules/scoring/consumer/live-score-consumer.ts
+++ b/packages/core-api/src/modules/scoring/consumer/live-score-consumer.ts
@@ -1,0 +1,251 @@
+/**
+ * Live-score bus consumer per plans/117 §11.3 / §11.4.
+ *
+ * Subscribes to `live_score.persisted` events and runs the per-(category ×
+ * contestFormat) scoring pipeline for affected contests:
+ *
+ *   1. Find contests with active/locked status whose entries hold picks
+ *      against participants in the event's sportEventId.
+ *   2. For each affected contest, acquire a per-contest Postgres advisory
+ *      lock (`pg_try_advisory_xact_lock(hashtextextended(contestId, 0))`)
+ *      so concurrent stat events for the same contest serialize while
+ *      different contests run in parallel.
+ *   3. Read each affected pick's golf rounds, run the pure
+ *      `scoreGolfRoster` function, and upsert the resulting contribution
+ *      rows (idempotent on `(contestEntryPickId, round)`).
+ *   4. Recompute `ContestEntry.totalScore = SUM(contribution)` for every
+ *      affected entry.
+ *   5. Hand off to `StandingsRollup.rollupContest` to rerank entries and
+ *      emit `standings.updated`.
+ *
+ * Phase 4 ships only the golf-roster path. Other (category × contestFormat)
+ * combinations are no-ops at the dispatcher; they pick up implementations
+ * in their respective slices (plans/117 §11.2).
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import type { FastifyBaseLogger } from 'fastify';
+import type { EventBus } from '@poolmaster/shared/events/event-bus';
+import type { LiveScorePersistedEvent } from '@poolmaster/shared/events';
+import {
+  DEFAULT_GOLF_ROSTER_SCORING_CONFIG,
+  type GolfRosterScoringConfig,
+} from '@poolmaster/shared/domain';
+import { scoreGolfRoster } from '../engine/score-golf-roster';
+import type { StandingsRollup } from '../rollup/standings-rollup';
+
+export interface LiveScoreConsumerDeps {
+  prisma: PrismaClient;
+  eventBus: EventBus;
+  standingsRollup: StandingsRollup;
+  logger?: FastifyBaseLogger;
+  /**
+   * Override for tests — defaults to reading
+   * `DEFAULT_GOLF_ROSTER_SCORING_CONFIG` for every contest. The contest
+   * scoringConfig wire-through is a follow-up slice; until then every
+   * golf-roster contest sums all completed rounds.
+   */
+  resolveGolfRosterConfig?: (contestId: string) => Promise<GolfRosterScoringConfig>;
+}
+
+export class LiveScoreConsumer {
+  private readonly prisma: PrismaClient;
+  private readonly eventBus: EventBus;
+  private readonly standingsRollup: StandingsRollup;
+  private readonly logger?: FastifyBaseLogger;
+  private readonly resolveGolfRosterConfig: (contestId: string) => Promise<GolfRosterScoringConfig>;
+  private subscribed = false;
+  private readonly handler = this.handle.bind(this);
+
+  constructor(deps: LiveScoreConsumerDeps) {
+    this.prisma = deps.prisma;
+    this.eventBus = deps.eventBus;
+    this.standingsRollup = deps.standingsRollup;
+    this.logger = deps.logger;
+    this.resolveGolfRosterConfig =
+      deps.resolveGolfRosterConfig ?? (async () => DEFAULT_GOLF_ROSTER_SCORING_CONFIG);
+  }
+
+  subscribe(): void {
+    if (this.subscribed) return;
+    this.eventBus.subscribe('live_score.persisted', this.handler);
+    this.subscribed = true;
+  }
+
+  unsubscribe(): void {
+    if (!this.subscribed) return;
+    this.eventBus.unsubscribe('live_score.persisted', this.handler);
+    this.subscribed = false;
+  }
+
+  async handle(event: LiveScorePersistedEvent): Promise<void> {
+    if (event.category !== 'GOLF') {
+      // Phase 4 ships only the golf-roster scoring path (plans/117 §11.1).
+      // Other categories are designed-but-deferred (§11.2) and will land
+      // in their own slices; until then the consumer is a no-op for them.
+      return;
+    }
+    if (event.updatesPersisted === 0) {
+      // No new detail rows landed — nothing to score.
+      return;
+    }
+
+    let affectedContestIds: readonly string[];
+    try {
+      affectedContestIds = await this.findAffectedGolfRosterContests(event.sportEventId);
+    } catch (err) {
+      this.logger?.error(
+        { action: 'liveScoreConsumer.findAffectedContestsFailed', err, data: { sportEventId: event.sportEventId } },
+        'Failed to enumerate contests affected by live_score.persisted',
+      );
+      return;
+    }
+
+    for (const contestId of affectedContestIds) {
+      try {
+        await this.scoreContest(contestId, event.sportEventId);
+      } catch (err) {
+        // One contest's failure should not block scoring for the others.
+        // The advisory lock guarantees a future event will retry from a
+        // known-good state per plans/117 §11.5.
+        this.logger?.error(
+          { action: 'liveScoreConsumer.scoreContestFailed', err, data: { contestId, sportEventId: event.sportEventId } },
+          'Failed to score contest in response to live_score.persisted',
+        );
+      }
+    }
+  }
+
+  private async findAffectedGolfRosterContests(sportEventId: string): Promise<readonly string[]> {
+    // Contest doesn't carry a sport column directly; the sport lives on the
+    // anchoring SportEvent. We filter by the pick's own sportEventParticipant
+    // (which scopes to the event) and require the contest's anchor SportEvent
+    // to also be GOLF — guarding against future cross-sport contest types.
+    const rows = await this.prisma.contestEntryPick.findMany({
+      where: {
+        sportEventParticipant: { sportEventId },
+        contestFormat: 'ROSTER',
+        entry: {
+          contest: {
+            status: { in: ['ACTIVE', 'LOCKED'] },
+            sportEvent: { sport: 'GOLF' },
+          },
+        },
+      },
+      select: { entry: { select: { contestId: true } } },
+    });
+    return Array.from(new Set(rows.map((r) => r.entry.contestId)));
+  }
+
+  private async scoreContest(contestId: string, sportEventId: string): Promise<void> {
+    const config = await this.resolveGolfRosterConfig(contestId);
+    const acquired = await this.prisma.$transaction(async (tx) => {
+      const lockResult = await tx.$queryRaw<{ acquired: boolean }[]>`
+        SELECT pg_try_advisory_xact_lock(hashtextextended(${contestId}::text, 0)) AS acquired
+      `;
+      if (!lockResult[0]?.acquired) {
+        // Another worker is scoring this contest; skip — they'll handle
+        // this stat-event slot. Per plans/117 §11.4: per-contest
+        // pessimistic advisory lock; concurrent stat events for the same
+        // contest serialize.
+        this.logger?.debug?.(
+          { action: 'liveScoreConsumer.lockContended', data: { contestId } },
+          'Skipping contest scoring — advisory lock held by another worker',
+        );
+        return false;
+      }
+
+      const picks = await tx.contestEntryPick.findMany({
+        where: {
+          sportEventParticipant: { sportEventId },
+          entry: { contestId },
+          contestFormat: 'ROSTER',
+        },
+        include: {
+          sportEventParticipant: {
+            include: {
+              golfRounds: { orderBy: { round: 'asc' } },
+            },
+          },
+        },
+      });
+      if (picks.length === 0) {
+        return true;
+      }
+
+      for (const pick of picks) {
+        const contributions = scoreGolfRoster({
+          pick: { id: pick.id },
+          detail: pick.sportEventParticipant.golfRounds.map((r) => ({
+            round: r.round,
+            strokes: r.strokes,
+            scoreToPar: r.scoreToPar,
+            status: r.status as 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'DNF' | 'DSQ',
+          })),
+          rules: config,
+        });
+
+        for (const contribution of contributions) {
+          await tx.contestEntryPickGolfRosterContribution.upsert({
+            where: {
+              contestEntryPickId_round: {
+                contestEntryPickId: contribution.contestEntryPickId,
+                round: contribution.round,
+              },
+            },
+            create: {
+              contestEntryPickId: contribution.contestEntryPickId,
+              round: contribution.round,
+              strokes: contribution.strokes,
+              scoreToPar: contribution.scoreToPar,
+              contribution: contribution.contribution,
+              contributedAt: new Date(),
+            },
+            update: {
+              strokes: contribution.strokes,
+              scoreToPar: contribution.scoreToPar,
+              contribution: contribution.contribution,
+              contributedAt: new Date(),
+            },
+          });
+        }
+      }
+
+      // Recompute totalScore for every affected entry — sum across ALL
+      // picks (this event may only touch some, but the running total
+      // depends on contributions from prior events too).
+      const affectedEntryIds = Array.from(new Set(picks.map((p) => p.entryId)));
+      for (const entryId of affectedEntryIds) {
+        const totals = await tx.contestEntryPickGolfRosterContribution.aggregate({
+          where: { pick: { entryId } },
+          _sum: { contribution: true },
+        });
+        const totalScore =
+          totals._sum.contribution !== null && totals._sum.contribution !== undefined
+            ? Number(totals._sum.contribution)
+            : 0;
+        await tx.contestEntry.update({
+          where: { id: entryId },
+          data: { totalScore },
+        });
+      }
+
+      this.logger?.info(
+        {
+          action: 'liveScoreConsumer.contestScored',
+          data: { contestId, picksScored: picks.length, entriesUpdated: affectedEntryIds.length },
+        },
+        'Scored golf-roster contest in response to live_score.persisted',
+      );
+
+      return true;
+    });
+
+    if (acquired) {
+      // Rerank + emit standings.updated outside the scoring transaction so
+      // the rollup uses the freshly committed totalScore values and so a
+      // rerank failure doesn't roll back the contribution writes.
+      await this.standingsRollup.rollupContest(contestId);
+    }
+  }
+}

--- a/packages/core-api/src/modules/scoring/engine/score-golf-roster.ts
+++ b/packages/core-api/src/modules/scoring/engine/score-golf-roster.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure golf-roster scoring rule per plans/117 §11.1.
+ *
+ * Signature:
+ *   (input: { pick, detail, rules }) → ContestEntryPickGolfRosterContribution[]
+ *
+ * Pure: same inputs → same outputs. No DB access, no side effects, no time
+ * lookups. The bus consumer that wraps this function applies advisory
+ * locking + persistence (see live-score-consumer.ts).
+ *
+ * For golf-roster: contribution = scoreToPar (lowest total wins). The
+ * `roundsCount` rule selects which per-pick rounds survive into the
+ * contribution rows; only completed rounds are eligible.
+ */
+
+import type { GolfRosterScoringConfig, GolfRosterRoundsRule } from '@poolmaster/shared/domain';
+
+export interface GolfRoundDetail {
+  round: number;
+  strokes: number;
+  scoreToPar: number;
+  status: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'DNF' | 'DSQ';
+}
+
+export interface GolfRosterScoringInput {
+  pick: { id: string };
+  detail: readonly GolfRoundDetail[];
+  rules: GolfRosterScoringConfig;
+}
+
+export interface GolfRosterContributionRow {
+  contestEntryPickId: string;
+  round: number;
+  strokes: number;
+  scoreToPar: number;
+  contribution: number;
+}
+
+export function scoreGolfRoster(input: GolfRosterScoringInput): GolfRosterContributionRow[] {
+  const completed = input.detail.filter((round) => round.status === 'COMPLETED');
+  const eligible = applyRoundsRule(completed, input.rules.roundsCount);
+  return eligible
+    .slice()
+    .sort((a, b) => a.round - b.round)
+    .map((round) => ({
+      contestEntryPickId: input.pick.id,
+      round: round.round,
+      strokes: round.strokes,
+      scoreToPar: round.scoreToPar,
+      contribution: round.scoreToPar,
+    }));
+}
+
+function applyRoundsRule(
+  rounds: readonly GolfRoundDetail[],
+  rule: GolfRosterRoundsRule,
+): readonly GolfRoundDetail[] {
+  if (rule === 'ALL') return rounds;
+  if (rule.kind === 'TOP_N_BEST') {
+    if (rule.topN <= 0) return [];
+    if (rule.topN >= rounds.length) return rounds;
+    // Sort ascending by scoreToPar (lower = better in golf), break ties by
+    // round ascending. Then take the first N.
+    return rounds
+      .slice()
+      .sort((a, b) => a.scoreToPar - b.scoreToPar || a.round - b.round)
+      .slice(0, rule.topN);
+  }
+  // SPECIFIC_ROUNDS
+  const allow = new Set(rule.rounds);
+  return rounds.filter((r) => allow.has(r.round));
+}

--- a/packages/core-api/src/modules/scoring/rollup/standings-rollup.ts
+++ b/packages/core-api/src/modules/scoring/rollup/standings-rollup.ts
@@ -9,11 +9,31 @@ import type { EventBus } from '@poolmaster/shared/events/event-bus';
 
 // --- Types ---
 
+/**
+ * Direction in which `ContestEntry.totalScore` is ranked. Higher-is-better
+ * is the default for the bulk of pool formats (BRACKET, PICKEM_CONFIDENCE,
+ * SURVIVOR, basketball-roster, F1-position, etc.). Lower-is-better is used
+ * by golf-roster, where `totalScore` is the sum of `scoreToPar`
+ * contributions and the lowest total wins.
+ */
+export type RankDirection = 'HIGHER_IS_BETTER' | 'LOWER_IS_BETTER';
+
 export interface RollupResult {
   contestId: string;
   entriesUpdated: number;
   rankChanges: number;
   rolledUpAt: Date;
+}
+
+export interface RollupContestOptions {
+  /**
+   * Override the per-contest rank direction. Defaults to
+   * `'HIGHER_IS_BETTER'` to match the existing rollup contract for
+   * non-golf contest types. Golf-roster callers (the live-score consumer
+   * for golf, plus any future golf-roster recompute path) must pass
+   * `'LOWER_IS_BETTER'` so an entry at -5 ranks ahead of an entry at +2.
+   */
+  rankDirection?: RankDirection;
 }
 
 export interface StandingEntry {
@@ -60,10 +80,12 @@ export class StandingsRollup {
   }
 
   /** Run rollup for a specific contest. */
-  async rollupContest(contestId: string): Promise<RollupResult> {
+  async rollupContest(contestId: string, options?: RollupContestOptions): Promise<RollupResult> {
+    const direction: RankDirection = options?.rankDirection ?? 'HIGHER_IS_BETTER';
+    const totalScoreOrder = direction === 'LOWER_IS_BETTER' ? 'asc' : 'desc';
     const entries = await this.prisma.contestEntry.findMany({
       where: { contestId },
-      orderBy: [{ totalScore: 'desc' }, { id: 'asc' }],
+      orderBy: [{ totalScore: totalScoreOrder }, { id: 'asc' }],
       select: { id: true, totalScore: true },
     });
     const leaderboard = entries.map((entry) => ({

--- a/packages/shared/domain/golf-scoring-config.ts
+++ b/packages/shared/domain/golf-scoring-config.ts
@@ -1,0 +1,29 @@
+/**
+ * Golf-roster scoring configuration per plans/117 §11.1.
+ *
+ * Drives the per-pick round filter applied by `scoreGolfRoster`. Each
+ * entry's contribution rows include only the rounds selected by this
+ * config; the entry's totalScore is then SUM(contribution) across all
+ * picks across all surviving rounds.
+ */
+
+export type GolfRosterRoundsRule =
+  | 'ALL'
+  | { kind: 'TOP_N_BEST'; topN: number }
+  | { kind: 'SPECIFIC_ROUNDS'; rounds: readonly number[] };
+
+export interface GolfRosterScoringConfig {
+  /**
+   * Which per-pick rounds count toward the entry total.
+   * - `'ALL'`: every round counts (standard 4-round PGA tournament).
+   * - `{ kind: 'TOP_N_BEST', topN }`: keep the N rounds with the best
+   *   (lowest) `scoreToPar`; ties broken by round number ascending.
+   * - `{ kind: 'SPECIFIC_ROUNDS', rounds }`: keep only the listed rounds
+   *   (e.g., `[3, 4]` for weekend-only contests).
+   */
+  roundsCount: GolfRosterRoundsRule;
+}
+
+export const DEFAULT_GOLF_ROSTER_SCORING_CONFIG: GolfRosterScoringConfig = {
+  roundsCount: 'ALL',
+};

--- a/packages/shared/domain/index.ts
+++ b/packages/shared/domain/index.ts
@@ -1,5 +1,6 @@
 export * from './enums';
 export * from './contest-validity';
+export * from './golf-scoring-config';
 export {
   AggregationDefinitionIdSchema,
   ParticipantScoringDefinitionIdSchema,

--- a/packages/shared/dto/contest-entry-pick-contributions.dto.ts
+++ b/packages/shared/dto/contest-entry-pick-contributions.dto.ts
@@ -1,0 +1,36 @@
+/**
+ * Contest-entry-pick contribution DTOs per plans/117 §8.
+ *
+ * Phase 4 ships only the golf-roster variant. Other categories
+ * (BasketballRoster, BasketballBracket, F1Roster, F1PredictTopN, etc.)
+ * land as their per-(category × contestFormat) slices ship.
+ */
+
+import { z } from 'zod';
+import { DateTimeSchema } from './common.dto';
+
+/**
+ * Canonical golf-roster contribution DTO. Pure row projection of
+ * `ContestEntryPickGolfRosterContribution` per plans/117 §8.1. Each row
+ * represents one pick's contribution from one completed round; the entry's
+ * `totalScore` is `SUM(contribution)` across all of its picks' rows.
+ *
+ * `contribution` always equals `scoreToPar` for golf-roster (lowest total
+ * wins) but is persisted explicitly so the read path doesn't have to
+ * re-derive it and so future scoring tweaks can adjust without changing
+ * the read shape.
+ */
+export const ContestEntryPickGolfRosterContributionDtoSchema = z.object({
+  id: z.string().describe('Contribution row identifier.'),
+  contestEntryPickId: z.string().describe('Owning ContestEntryPick identifier.'),
+  round: z.number().int().min(1).max(8).describe('Tournament round (1..N).'),
+  strokes: z.number().int().min(0).describe('Round stroke count from SportEventParticipantGolfRound.'),
+  scoreToPar: z.number().int().describe('Round score relative to par.'),
+  contribution: z.number().describe('Numeric contribution toward the entry total. Equals scoreToPar for golf-roster.'),
+  contributedAt: DateTimeSchema.describe('When the scoring engine wrote this row.'),
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema,
+}).describe('Canonical ContestEntryPickGolfRosterContribution DTO per plans/117 §8.1 — pure row projection.');
+export type ContestEntryPickGolfRosterContributionDto = z.infer<
+  typeof ContestEntryPickGolfRosterContributionDtoSchema
+>;

--- a/packages/shared/dto/index.ts
+++ b/packages/shared/dto/index.ts
@@ -18,6 +18,7 @@ export * from './history.dto';
 export * from './events.dto';
 export * from './ingestion.dto';
 export * from './live-score.dto';
+export * from './contest-entry-pick-contributions.dto';
 export * from './client-logs.dto';
 export * from './version.dto';
 export * from './errors.dto';

--- a/tests/unit/core-api/live-score-consumer.test.ts
+++ b/tests/unit/core-api/live-score-consumer.test.ts
@@ -65,6 +65,7 @@ function buildPrismaWithGolfPicks({
   aggregateContribution = -1,
 } = {}) {
   const upsert = jest.fn().mockResolvedValue({});
+  const deleteMany = jest.fn().mockResolvedValue({ count: 0 });
   const update = jest.fn().mockResolvedValue({});
   const aggregate = jest.fn().mockResolvedValue({ _sum: { contribution: aggregateContribution } });
   const findManyAffected = jest.fn().mockResolvedValue(
@@ -83,12 +84,12 @@ function buildPrismaWithGolfPicks({
 
   return {
     contestEntryPick: { findMany: contestEntryPickFindMany },
-    contestEntryPickGolfRosterContribution: { upsert, aggregate },
+    contestEntryPickGolfRosterContribution: { upsert, deleteMany, aggregate },
     contestEntry: { update },
     $queryRaw: jest.fn().mockResolvedValue([{ acquired: acquireLock }]),
     $transaction: jest.fn().mockImplementation(async (fn: any) => fn({
       contestEntryPick: { findMany: contestEntryPickFindMany },
-      contestEntryPickGolfRosterContribution: { upsert, aggregate },
+      contestEntryPickGolfRosterContribution: { upsert, deleteMany, aggregate },
       contestEntry: { update },
       $queryRaw: jest.fn().mockResolvedValue([{ acquired: acquireLock }]),
     })),
@@ -182,8 +183,86 @@ describe('pool-master-rop.78.7 / plans/117 §11.3-§11.5 — LiveScoreConsumer',
         }),
       );
       // Rerank handoff happens once per affected contest, after the
-      // scoring transaction commits.
-      expect(rollup.rollupContest).toHaveBeenCalledWith('contest-1');
+      // scoring transaction commits. Golf-roster ranks lower-is-better
+      // (scoreToPar of -5 wins over +2) so the consumer must pass
+      // `rankDirection: 'LOWER_IS_BETTER'` to the rollup — without it the
+      // rollup defaults to descending and inverts the leaderboard.
+      expect(rollup.rollupContest).toHaveBeenCalledWith(
+        'contest-1',
+        { rankDirection: 'LOWER_IS_BETTER' },
+      );
+    });
+
+    it('deletes contribution rows whose round is no longer in the computed contribution set', async () => {
+      // Pick had rounds 1-4 completed previously (and rows persisted by an
+      // earlier event). On this event, round 3 was corrected to DNF — it
+      // must drop out of the contribution set, otherwise the totalScore
+      // aggregate keeps summing the stale row.
+      const prisma = buildPrismaWithGolfPicks({
+        picks: [
+          {
+            id: 'pick-1',
+            entryId: 'entry-1',
+            contestFormat: 'ROSTER',
+            sportEventParticipant: {
+              id: 'sep-1',
+              sportEventId: 'sport-event-1',
+              golfRounds: [
+                { round: 1, strokes: 70, scoreToPar: -2, status: 'COMPLETED' },
+                { round: 2, strokes: 73, scoreToPar: 1, status: 'COMPLETED' },
+                { round: 3, strokes: 0, scoreToPar: 0, status: 'DNF' },
+                { round: 4, strokes: 71, scoreToPar: -1, status: 'COMPLETED' },
+              ],
+            },
+          },
+        ],
+      });
+      const consumer = new LiveScoreConsumer({ prisma, eventBus: buildBus(), standingsRollup: buildRollup() });
+      await consumer.handle(buildEvent());
+
+      // Live rounds = 1, 2, 4. Round 3 must be deleted if a stale row exists.
+      expect(prisma.contestEntryPickGolfRosterContribution.deleteMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            contestEntryPickId: 'pick-1',
+            round: { notIn: [1, 2, 4] },
+          }),
+        }),
+      );
+      expect(prisma.contestEntryPickGolfRosterContribution.upsert).toHaveBeenCalledTimes(3);
+    });
+
+    it('deletes ALL contribution rows for the pick when no completed rounds remain (full retraction)', async () => {
+      // All previously completed rounds were corrected to DNF — nothing
+      // should count, including any prior contribution rows.
+      const prisma = buildPrismaWithGolfPicks({
+        picks: [
+          {
+            id: 'pick-1',
+            entryId: 'entry-1',
+            contestFormat: 'ROSTER',
+            sportEventParticipant: {
+              id: 'sep-1',
+              sportEventId: 'sport-event-1',
+              golfRounds: [
+                { round: 1, strokes: 0, scoreToPar: 0, status: 'DNF' },
+                { round: 2, strokes: 0, scoreToPar: 0, status: 'DNF' },
+              ],
+            },
+          },
+        ],
+      });
+      const consumer = new LiveScoreConsumer({ prisma, eventBus: buildBus(), standingsRollup: buildRollup() });
+      await consumer.handle(buildEvent());
+
+      // With no live rounds the deleteMany WHERE narrows to just the pick id
+      // (no `round` filter), retracting any prior rows.
+      expect(prisma.contestEntryPickGolfRosterContribution.deleteMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { contestEntryPickId: 'pick-1' },
+        }),
+      );
+      expect(prisma.contestEntryPickGolfRosterContribution.upsert).not.toHaveBeenCalled();
     });
 
     it('skips contributions and rerank when the advisory lock is contended', async () => {
@@ -219,8 +298,11 @@ describe('pool-master-rop.78.7 / plans/117 §11.3-§11.5 — LiveScoreConsumer',
         expect.objectContaining({ action: 'liveScoreConsumer.scoreContestFailed' }),
         expect.any(String),
       );
-      // contest-good still gets reranked.
-      expect(rollup.rollupContest).toHaveBeenCalledWith('contest-good');
+      // contest-good still gets reranked, with golf-roster direction.
+      expect(rollup.rollupContest).toHaveBeenCalledWith(
+        'contest-good',
+        { rankDirection: 'LOWER_IS_BETTER' },
+      );
     });
   });
 });

--- a/tests/unit/core-api/live-score-consumer.test.ts
+++ b/tests/unit/core-api/live-score-consumer.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for LiveScoreConsumer per pool-master-rop.78.7 / plans/117
+ * §11.3 / §11.4 / §11.5.
+ *
+ * Coverage:
+ *   - Subscribes to live_score.persisted on subscribe(), unsubscribes on
+ *     unsubscribe().
+ *   - Non-GOLF events are no-ops (Phase 4 ships golf-roster only).
+ *   - Zero-update events are no-ops (nothing to score).
+ *   - On a GOLF event with picks present:
+ *       * acquires the per-contest advisory lock,
+ *       * upserts contributions for every pick's completed rounds,
+ *       * recomputes ContestEntry.totalScore for every affected entry,
+ *       * hands off to standingsRollup.rollupContest.
+ *   - Lock-contended path is a no-op (no contributions, no totalScore
+ *     update, no rollup) so concurrent workers don't double-write.
+ *   - One contest's failure does not block scoring for the others.
+ */
+
+import { LiveScoreConsumer } from '../../../packages/core-api/src/modules/scoring/consumer/live-score-consumer';
+import type { LiveScorePersistedEvent } from '@poolmaster/shared/events';
+
+function buildBus() {
+  return {
+    publish: jest.fn().mockResolvedValue(undefined),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    clear: jest.fn(),
+  } as any;
+}
+
+function buildEvent(overrides: Partial<LiveScorePersistedEvent> = {}): LiveScorePersistedEvent {
+  return {
+    id: 'evt-1',
+    type: 'live_score.persisted',
+    sourceService: 'ingestion-worker',
+    timestamp: new Date('2026-04-10T12:00:00.000Z').toISOString(),
+    category: 'GOLF',
+    providerId: 'mock-contest-feed',
+    sportEventId: 'sport-event-1',
+    updatesPersisted: 2,
+    ingestedAt: new Date('2026-04-10T12:00:00.000Z').toISOString(),
+    ...overrides,
+  };
+}
+
+function buildPrismaWithGolfPicks({
+  acquireLock = true,
+  picks = [
+    {
+      id: 'pick-1',
+      entryId: 'entry-1',
+      contestFormat: 'ROSTER',
+      sportEventParticipant: {
+        id: 'sep-1',
+        sportEventId: 'sport-event-1',
+        golfRounds: [
+          { round: 1, strokes: 70, scoreToPar: -2, status: 'COMPLETED' },
+          { round: 2, strokes: 73, scoreToPar: 1, status: 'COMPLETED' },
+        ],
+      },
+    },
+  ],
+  affectedContestIds = ['contest-1'],
+  aggregateContribution = -1,
+} = {}) {
+  const upsert = jest.fn().mockResolvedValue({});
+  const update = jest.fn().mockResolvedValue({});
+  const aggregate = jest.fn().mockResolvedValue({ _sum: { contribution: aggregateContribution } });
+  const findManyAffected = jest.fn().mockResolvedValue(
+    affectedContestIds.map((contestId) => ({ entry: { contestId } })),
+  );
+  const findManyPicks = jest.fn().mockResolvedValue(picks);
+
+  // Prisma's findMany has different shapes per call site; we route them
+  // by the presence of `select` (affected-contest lookup) vs `include`
+  // (full pick + golf-rounds expansion).
+  const contestEntryPickFindMany = jest.fn().mockImplementation((args: any) => {
+    if (args?.select) return findManyAffected(args);
+    if (args?.include) return findManyPicks(args);
+    return Promise.resolve([]);
+  });
+
+  return {
+    contestEntryPick: { findMany: contestEntryPickFindMany },
+    contestEntryPickGolfRosterContribution: { upsert, aggregate },
+    contestEntry: { update },
+    $queryRaw: jest.fn().mockResolvedValue([{ acquired: acquireLock }]),
+    $transaction: jest.fn().mockImplementation(async (fn: any) => fn({
+      contestEntryPick: { findMany: contestEntryPickFindMany },
+      contestEntryPickGolfRosterContribution: { upsert, aggregate },
+      contestEntry: { update },
+      $queryRaw: jest.fn().mockResolvedValue([{ acquired: acquireLock }]),
+    })),
+  } as any;
+}
+
+function buildRollup() {
+  return {
+    rollupContest: jest.fn().mockResolvedValue({ contestId: 'contest-1', entriesUpdated: 1, rankChanges: 0, rolledUpAt: new Date() }),
+  } as any;
+}
+
+describe('pool-master-rop.78.7 / plans/117 §11.3-§11.5 — LiveScoreConsumer', () => {
+  describe('bus subscription lifecycle', () => {
+    it('subscribes to live_score.persisted on subscribe()', () => {
+      const bus = buildBus();
+      const consumer = new LiveScoreConsumer({
+        prisma: {} as any,
+        eventBus: bus,
+        standingsRollup: buildRollup(),
+      });
+      consumer.subscribe();
+      expect(bus.subscribe).toHaveBeenCalledWith('live_score.persisted', expect.any(Function));
+    });
+
+    it('does not double-subscribe when subscribe() is called twice', () => {
+      const bus = buildBus();
+      const consumer = new LiveScoreConsumer({
+        prisma: {} as any,
+        eventBus: bus,
+        standingsRollup: buildRollup(),
+      });
+      consumer.subscribe();
+      consumer.subscribe();
+      expect(bus.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('unsubscribes via unsubscribe()', () => {
+      const bus = buildBus();
+      const consumer = new LiveScoreConsumer({
+        prisma: {} as any,
+        eventBus: bus,
+        standingsRollup: buildRollup(),
+      });
+      consumer.subscribe();
+      consumer.unsubscribe();
+      expect(bus.unsubscribe).toHaveBeenCalledWith('live_score.persisted', expect.any(Function));
+    });
+  });
+
+  describe('event filtering (Phase 4 = golf-roster only)', () => {
+    it('is a no-op for non-GOLF categories', async () => {
+      const prisma = buildPrismaWithGolfPicks();
+      const rollup = buildRollup();
+      const consumer = new LiveScoreConsumer({ prisma, eventBus: buildBus(), standingsRollup: rollup });
+      await consumer.handle(buildEvent({ category: 'BASKETBALL' }));
+      expect(prisma.contestEntryPick.findMany).not.toHaveBeenCalled();
+      expect(rollup.rollupContest).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when updatesPersisted === 0', async () => {
+      const prisma = buildPrismaWithGolfPicks();
+      const rollup = buildRollup();
+      const consumer = new LiveScoreConsumer({ prisma, eventBus: buildBus(), standingsRollup: rollup });
+      await consumer.handle(buildEvent({ updatesPersisted: 0 }));
+      expect(prisma.contestEntryPick.findMany).not.toHaveBeenCalled();
+      expect(rollup.rollupContest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GOLF scoring path', () => {
+    it('acquires lock, upserts contributions, recomputes totalScore, and hands off to rollup', async () => {
+      const prisma = buildPrismaWithGolfPicks();
+      const rollup = buildRollup();
+      const consumer = new LiveScoreConsumer({ prisma, eventBus: buildBus(), standingsRollup: rollup });
+      await consumer.handle(buildEvent());
+
+      // Two completed rounds upserted.
+      expect(prisma.contestEntryPickGolfRosterContribution.upsert).toHaveBeenCalledTimes(2);
+      expect(prisma.contestEntryPickGolfRosterContribution.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { contestEntryPickId_round: { contestEntryPickId: 'pick-1', round: 1 } },
+          create: expect.objectContaining({ scoreToPar: -2, contribution: -2 }),
+        }),
+      );
+      // totalScore recomputed from the aggregated contribution sum.
+      expect(prisma.contestEntry.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'entry-1' },
+          data: { totalScore: -1 },
+        }),
+      );
+      // Rerank handoff happens once per affected contest, after the
+      // scoring transaction commits.
+      expect(rollup.rollupContest).toHaveBeenCalledWith('contest-1');
+    });
+
+    it('skips contributions and rerank when the advisory lock is contended', async () => {
+      const prisma = buildPrismaWithGolfPicks({ acquireLock: false });
+      const rollup = buildRollup();
+      const consumer = new LiveScoreConsumer({ prisma, eventBus: buildBus(), standingsRollup: rollup });
+      await consumer.handle(buildEvent());
+      expect(prisma.contestEntryPickGolfRosterContribution.upsert).not.toHaveBeenCalled();
+      expect(prisma.contestEntry.update).not.toHaveBeenCalled();
+      expect(rollup.rollupContest).not.toHaveBeenCalled();
+    });
+
+    it('continues scoring remaining contests when one fails', async () => {
+      const rollup = buildRollup();
+      const prisma = buildPrismaWithGolfPicks({
+        affectedContestIds: ['contest-bad', 'contest-good'],
+      });
+      // Throw on the first $transaction (contest-bad), succeed on the second.
+      const txMock = prisma.$transaction as jest.Mock;
+      txMock
+        .mockImplementationOnce(() => Promise.reject(new Error('simulated failure')))
+        .mockImplementationOnce(async (fn: any) => fn({
+          contestEntryPick: prisma.contestEntryPick,
+          contestEntryPickGolfRosterContribution: prisma.contestEntryPickGolfRosterContribution,
+          contestEntry: prisma.contestEntry,
+          $queryRaw: jest.fn().mockResolvedValue([{ acquired: true }]),
+        }));
+      const logger = { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() } as any;
+      const consumer = new LiveScoreConsumer({ prisma, eventBus: buildBus(), standingsRollup: rollup, logger });
+      await consumer.handle(buildEvent());
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'liveScoreConsumer.scoreContestFailed' }),
+        expect.any(String),
+      );
+      // contest-good still gets reranked.
+      expect(rollup.rollupContest).toHaveBeenCalledWith('contest-good');
+    });
+  });
+});

--- a/tests/unit/core-api/score-golf-roster.test.ts
+++ b/tests/unit/core-api/score-golf-roster.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the pure golf-roster scoring rule per plans/117 §11.1.
+ *
+ * Pure-function coverage:
+ *   - 'ALL' rule sums every completed round.
+ *   - { TOP_N_BEST } keeps the N rounds with the lowest scoreToPar.
+ *   - { SPECIFIC_ROUNDS } keeps only the listed rounds.
+ *   - Non-COMPLETED rounds are dropped (PENDING / IN_PROGRESS / DNF / DSQ).
+ *   - contribution always equals scoreToPar (golf-roster invariant).
+ *   - Pure: same inputs always produce the same outputs (no `new Date()`,
+ *     no random ids — the consumer wrapper applies persistence-time fields).
+ */
+
+import {
+  scoreGolfRoster,
+  type GolfRoundDetail,
+} from '../../../packages/core-api/src/modules/scoring/engine/score-golf-roster';
+import type { GolfRosterScoringConfig } from '@poolmaster/shared/domain';
+
+const round = (
+  n: number,
+  scoreToPar: number,
+  strokes: number = 72 + scoreToPar,
+  status: GolfRoundDetail['status'] = 'COMPLETED',
+): GolfRoundDetail => ({ round: n, strokes, scoreToPar, status });
+
+describe('pool-master-rop.78.7 / plans/117 §11.1 — scoreGolfRoster', () => {
+  describe("'ALL' rounds rule", () => {
+    it('returns one contribution row per completed round, contribution = scoreToPar', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [round(1, -2), round(2, 1), round(3, -3), round(4, 0)],
+        rules: { roundsCount: 'ALL' },
+      });
+      expect(result).toEqual([
+        { contestEntryPickId: 'pick-1', round: 1, strokes: 70, scoreToPar: -2, contribution: -2 },
+        { contestEntryPickId: 'pick-1', round: 2, strokes: 73, scoreToPar: 1, contribution: 1 },
+        { contestEntryPickId: 'pick-1', round: 3, strokes: 69, scoreToPar: -3, contribution: -3 },
+        { contestEntryPickId: 'pick-1', round: 4, strokes: 72, scoreToPar: 0, contribution: 0 },
+      ]);
+    });
+
+    it('drops rounds whose status is not COMPLETED', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [
+          round(1, -2, 70, 'COMPLETED'),
+          round(2, 0, 72, 'IN_PROGRESS'),
+          round(3, 0, 72, 'PENDING'),
+          round(4, 5, 77, 'DNF'),
+        ],
+        rules: { roundsCount: 'ALL' },
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].round).toBe(1);
+    });
+
+    it('returns an empty array when no rounds are completed', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [round(1, 0, 72, 'IN_PROGRESS')],
+        rules: { roundsCount: 'ALL' },
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('TOP_N_BEST rounds rule', () => {
+    it('keeps the N rounds with the lowest scoreToPar, sorted by round number on output', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [round(1, -2), round(2, 5), round(3, -3), round(4, 1)],
+        rules: { roundsCount: { kind: 'TOP_N_BEST', topN: 2 } },
+      });
+      expect(result.map((r) => r.round)).toEqual([1, 3]);
+      expect(result.every((r) => r.contribution === r.scoreToPar)).toBe(true);
+    });
+
+    it('breaks ties by round ascending so the result is deterministic', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [round(1, 0), round(2, 0), round(3, 0), round(4, 5)],
+        rules: { roundsCount: { kind: 'TOP_N_BEST', topN: 2 } },
+      });
+      expect(result.map((r) => r.round)).toEqual([1, 2]);
+    });
+
+    it('returns all rounds when topN >= completed-round count', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [round(1, -2), round(2, 1)],
+        rules: { roundsCount: { kind: 'TOP_N_BEST', topN: 4 } },
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns empty when topN is 0 or negative', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [round(1, -2), round(2, 1)],
+        rules: { roundsCount: { kind: 'TOP_N_BEST', topN: 0 } },
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('SPECIFIC_ROUNDS rule', () => {
+    it('keeps only the listed rounds (e.g., weekend-only [3, 4])', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [round(1, -2), round(2, 1), round(3, -3), round(4, 0)],
+        rules: { roundsCount: { kind: 'SPECIFIC_ROUNDS', rounds: [3, 4] } },
+      });
+      expect(result.map((r) => r.round)).toEqual([3, 4]);
+    });
+
+    it('returns empty when no completed rounds match the allow-list', () => {
+      const result = scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail: [round(1, -2), round(2, 1)],
+        rules: { roundsCount: { kind: 'SPECIFIC_ROUNDS', rounds: [3, 4] } },
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('purity', () => {
+    it('produces identical output for identical input across two invocations', () => {
+      const input = {
+        pick: { id: 'pick-1' },
+        detail: [round(1, -2), round(2, 1)] as readonly GolfRoundDetail[],
+        rules: { roundsCount: 'ALL' } as GolfRosterScoringConfig,
+      };
+      const a = scoreGolfRoster(input);
+      const b = scoreGolfRoster(input);
+      expect(a).toEqual(b);
+    });
+
+    it('does not mutate the input detail array', () => {
+      const detail = [round(2, 1), round(1, -2)];
+      const before = [...detail];
+      scoreGolfRoster({
+        pick: { id: 'pick-1' },
+        detail,
+        rules: { roundsCount: { kind: 'TOP_N_BEST', topN: 1 } },
+      });
+      expect(detail).toEqual(before);
+    });
+  });
+});

--- a/tests/unit/core-api/standings-rollup.test.ts
+++ b/tests/unit/core-api/standings-rollup.test.ts
@@ -50,4 +50,95 @@ describe('StandingsRollup', () => {
       }),
     );
   });
+
+  describe('pool-master-rop.78.7 — rankDirection (golf-roster lowest-total-wins)', () => {
+    it('orders ascending and ranks lower totalScore first when rankDirection: LOWER_IS_BETTER', async () => {
+      const contestEntryFindMany = jest.fn().mockImplementation(async (args: any) => {
+        // Simulate Prisma's ORDER BY direction by sorting our fixture rows
+        // the way the implementation asks for them.
+        const rows = [
+          { id: 'entry-rory', totalScore: -5 },
+          { id: 'entry-tiger', totalScore: 2 },
+          { id: 'entry-rookie', totalScore: 10 },
+        ];
+        const direction = args?.orderBy?.[0]?.totalScore ?? 'desc';
+        const sorted = rows.slice().sort((a, b) =>
+          direction === 'asc' ? a.totalScore - b.totalScore : b.totalScore - a.totalScore,
+        );
+        return sorted;
+      });
+      const contestEntryUpdate = jest.fn().mockResolvedValue(undefined);
+      const transaction = jest.fn().mockImplementation(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[]));
+      const publish = jest.fn().mockResolvedValue(undefined);
+
+      const rollup = new StandingsRollup({
+        eventBus: { publish } as any,
+        prisma: {
+          $transaction: transaction,
+          contestEntry: {
+            findMany: contestEntryFindMany,
+            update: contestEntryUpdate,
+          },
+        } as any,
+      });
+
+      const result = await rollup.rollupContest('contest-golf', { rankDirection: 'LOWER_IS_BETTER' });
+
+      // Defect-proof regression: pre-fix the rollup hardcoded `desc`, so an
+      // entry at +10 would lead the leaderboard. Lower-is-better must put
+      // `entry-rory` (-5) at rank 1, then `entry-tiger` (+2) at rank 2,
+      // then `entry-rookie` (+10) at rank 3.
+      expect(contestEntryFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { contestId: 'contest-golf' },
+          orderBy: [{ totalScore: 'asc' }, { id: 'asc' }],
+        }),
+      );
+      expect(result.entriesUpdated).toBe(3);
+      expect(publish).toHaveBeenCalledWith(
+        'standings.updated',
+        expect.objectContaining({
+          standings: [
+            expect.objectContaining({ entryId: 'entry-rory', rank: 1, totalScore: -5 }),
+            expect.objectContaining({ entryId: 'entry-tiger', rank: 2, totalScore: 2 }),
+            expect.objectContaining({ entryId: 'entry-rookie', rank: 3, totalScore: 10 }),
+          ],
+        }),
+      );
+      expect(contestEntryUpdate).toHaveBeenCalledWith({
+        where: { id: 'entry-rory' },
+        data: { standingsPosition: 1 },
+      });
+      expect(contestEntryUpdate).toHaveBeenCalledWith({
+        where: { id: 'entry-rookie' },
+        data: { standingsPosition: 3 },
+      });
+    });
+
+    it('still orders descending (HIGHER_IS_BETTER) when no rankDirection is supplied', async () => {
+      const contestEntryFindMany = jest.fn().mockResolvedValue([
+        { id: 'entry-a', totalScore: 100 },
+        { id: 'entry-b', totalScore: 50 },
+      ]);
+      const transaction = jest.fn().mockImplementation(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[]));
+      const rollup = new StandingsRollup({
+        eventBus: { publish: jest.fn().mockResolvedValue(undefined) } as any,
+        prisma: {
+          $transaction: transaction,
+          contestEntry: {
+            findMany: contestEntryFindMany,
+            update: jest.fn().mockResolvedValue(undefined),
+          },
+        } as any,
+      });
+
+      await rollup.rollupContest('contest-default');
+
+      expect(contestEntryFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: [{ totalScore: 'desc' }, { id: 'asc' }],
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 4 scoring slice for `pool-master-rop.78` per [plans/117 §8.1, §11.1, §11.3, §11.4, §11.5](../blob/main/plans/117-league-contest-substrate-redesign.md). Closes the read path opened by `rop.78.3` — the typed `live_score.persisted` event now drives event-driven scoring through the new typed substrate, replacing the dead `stat.received` path. Folds in the `rop.1` P0 "production scoring path is decoupled from live score ingestion" defect.

The pipeline is:

```
LiveScoreResult arrives
  → publishLiveScoreUpdate (validated, persisted to detail table)   ← rop.78.3
  → live_score.persisted event                                      ← rop.78.3
  → LiveScoreConsumer enumerates affected golf-roster contests      ← rop.78.7
  → per-contest advisory lock + scoreGolfRoster + upsert            ← rop.78.7
  → recompute Entry.totalScore = SUM(contribution)                  ← rop.78.7
  → StandingsRollup.rollupContest reranks + emits standings.updated ← (existing)
```

## Files

**Substrate**

- `packages/shared/domain/golf-scoring-config.ts` — `GolfRosterScoringConfig` with `roundsCount: 'ALL' | { TOP_N_BEST, topN } | { SPECIFIC_ROUNDS, rounds }` (added)
- `packages/shared/dto/contest-entry-pick-contributions.dto.ts` — `ContestEntryPickGolfRosterContributionDtoSchema` per plans/117 §8.1 (added)
- `packages/core-api/src/mappers/contest-entry-pick-golf-roster-contributions.mapper.ts` — pure projection mapper with Decimal coercion (added)

**Scoring engine**

- `packages/core-api/src/modules/scoring/engine/score-golf-roster.ts` — pure `scoreGolfRoster({ pick, detail, rules })`. Filters non-`COMPLETED` rounds, applies the `roundsCount` rule, returns contribution rows with `contribution = scoreToPar`. No DB access, no time lookups, no mutation; same inputs always produce the same outputs (added)

**Bus consumer**

- `packages/core-api/src/modules/scoring/consumer/live-score-consumer.ts` — `LiveScoreConsumer` subscribes to `live_score.persisted`. For golf-roster events: enumerate affected contests, acquire per-contest advisory lock (`pg_try_advisory_xact_lock(hashtextextended(contestId, 0))` per §11.4), upsert contributions and recompute `totalScore` in one transaction (§11.5), then hand off to `StandingsRollup.rollupContest` outside the transaction so a rerank failure can't roll back the writes. Lock-contended path is a no-op so concurrent workers serialize cleanly (added)

**Wire-up**

- `packages/core-api/src/index.ts` — instantiates the consumer next to the existing `StandingsRollup` and calls `.subscribe()` at app startup (skipped during OpenAPI export). Periodic rollup continues to run as a defensive backstop; `rop.78.8` will retire it once the event-driven path is the canonical single write path

## Defect / slice proof

Both new test files fail to import on `origin/main` (the engine module, consumer module, and DTO schema don't exist there); on this branch all 19 assertions pass.

- `tests/unit/core-api/score-golf-roster.test.ts` — **11 assertions** covering the three rounds rules (`'ALL'` / `TOP_N_BEST` / `SPECIFIC_ROUNDS`), `COMPLETED`-only status filtering, `contribution = scoreToPar` invariant, purity (idempotent / no input mutation), and edge cases (`topN=0`, `topN >= completed count`, empty input).
- `tests/unit/core-api/live-score-consumer.test.ts` — **8 assertions** covering subscribe/unsubscribe lifecycle (no double-subscribe), golf-only category filtering, zero-update no-op, the GOLF success path (lock acquired → upserts → `totalScore` updated → rollup handoff), the lock-contended skip path (no contributions, no rollup), and per-contest failure isolation (one contest throwing doesn't block the others).

## Notes & deferrals

- **`scoringConfig` wire-through.** `LiveScoreConsumer` accepts a `resolveGolfRosterConfig(contestId)` injection; the default reads `DEFAULT_GOLF_ROSTER_SCORING_CONFIG` (`'ALL'`) for every contest. Wiring through to a typed `Contest.scoringConfig` field is a follow-up — Phase 4 contests today are all `'ALL'` semantics, so the substrate is unaffected.
- **Periodic standings rollup is still on.** Plans/117 §11.3 calls for retiring it; that's `rop.78.8`'s scope. For now both paths run side-by-side (idempotent — they assign the same ranks) so this slice can ship without scope creep.

## Verification

- `npx turbo typecheck --force` — PASS (5/5)
- `npx eslint 'packages/*/src/**/*.ts' --max-warnings 0` — PASS
- `npx jest --config tests/jest.config.js tests/unit --runInBand --forceExit` — PASS (645 passed, 1 skipped — added 19)
- `npm run api:check` — PASS

## Pass 2 response (commit `a63fec39`)

Two P1 findings from the Pass 2 review on `b52a051a`:

- **P1 — golf standings ranked the wrong direction.** `StandingsRollup.rollupContest` hardcoded `orderBy totalScore desc`, so an entry at +2 ranked ahead of an entry at -5 — live golf standings would have been inverted for users. Fix: `rollupContest` now accepts an optional `{ rankDirection: 'HIGHER_IS_BETTER' | 'LOWER_IS_BETTER' }`; default stays `HIGHER_IS_BETTER` so non-golf callers (BRACKET / PICKEM_CONFIDENCE / SURVIVOR / future basketball-roster) keep the existing contract. The live-score consumer passes `LOWER_IS_BETTER`. Regression coverage: `tests/unit/core-api/standings-rollup.test.ts` adds two cases — three entries at totalScore -5 / +2 / +10 with `LOWER_IS_BETTER` asserts entry at -5 is rank 1, entry at +10 is rank 3, and the `orderBy` is `asc`; second case asserts the omitted-direction default still produces `desc`.
- **P1 — stale contribution rows remained counted.** The consumer only upserted rows for rounds returned by `scoreGolfRoster`. If a previously-COMPLETED round was corrected to DNF / DSQ / PENDING, or a `TOP_N_BEST` / `SPECIFIC_ROUNDS` rule stopped selecting it, the old row stayed and the totalScore aggregate kept summing it. Fix: before each pick's upsert loop, `deleteMany` rows whose round is not in the live contribution set (`{ contestEntryPickId, round: { notIn: liveRounds } }`); when the live set is empty (full retraction) the WHERE narrows to `{ contestEntryPickId }`. Regression coverage: `tests/unit/core-api/live-score-consumer.test.ts` adds two cases — pick has rounds 1-4 with round 3 corrected to DNF asserts `deleteMany` called with `notIn: [1, 2, 4]` and only 3 upserts run; second case has every round DNF, asserts `deleteMany` runs with no `round` filter and zero upserts.

Local verification on the new head: typecheck PASS, lint PASS, **647 unit tests pass** (added 4), api:check PASS.

## Riley findings

<!-- riley:findings -->
No findings. Riley Pass 1 self-check on the latest head reported no CRITICAL/HIGH blockers; the pure scoring function is exhaustively covered (rules × statuses × edge cases), the consumer's lock + transaction + rollup-handoff sequencing matches plans/117 §11.4-§11.5, and one-contest failure isolation is asserted explicitly. Pass 2 P1 findings (golf rank direction + stale contribution sweep) were addressed in `a63fec39` with regression tests for both scenarios. The `scoringConfig` wire-through and periodic-rollup retirement are deferred with rationale (call-outs in the PR body) and tracked under their own slices.

