### PR TITLE
[pool-master-rop.78.8] Retire periodic StandingsRollup; event-driven scoring is the single write path

### DIFF
--- a/packages/core-api/src/index.ts
+++ b/packages/core-api/src/index.ts
@@ -256,12 +256,13 @@ export function buildApp() {
   // here. It dispatches per (event.category × pick.contestFormat) and runs
   // the scoring → contributions → totalScore → rerank pipeline under a
   // per-contest advisory lock (plans/117 §11.3, §11.4, §11.5).
-  // Periodic standings rollup continues to run as a defensive backstop;
-  // rop.78.8 will retire it once the event-driven path is the canonical
-  // single write path.
+  // pool-master-rop.78.8 — periodic StandingsRollup interval retired; the
+  // event-driven path is now the canonical single write path.
+  // ContestScoringRecalculationService remains for explicit triggers
+  // (admin override, contest reopen) but is no longer a parallel update
+  // mechanism that races with stat-event scoring (plans/117 §11.3).
   if (!isOpenApiExport) {
     liveScoreConsumer.subscribe();
-    standingsRollup.startPeriodicRollup();
   }
 
   // =========================================================================
@@ -302,7 +303,7 @@ export function buildApp() {
   });
 
   app.addHook('onClose', async () => {
-    standingsRollup.stopPeriodicRollup();
+    liveScoreConsumer.unsubscribe();
     ingestionScheduler.stop();
     eventBus.clear();
     await prisma.$disconnect();

--- a/packages/core-api/src/modules/scoring/handler.ts
+++ b/packages/core-api/src/modules/scoring/handler.ts
@@ -91,7 +91,7 @@ export function createGetHealthHandler(deps: ScoringHandlerDeps) {
     const logger = request.contextLogger ?? request.log;
     logger.debug('Handling scoring health read');
     const detail = deps.scoringService.getHealth();
-    logger.info({ rollupRunning: detail.rollupRunning, activeContests: detail.activeContests }, 'Handled scoring health read');
+    logger.info({ eventDriven: detail.eventDriven }, 'Handled scoring health read');
     return detail;
   };
 }

--- a/packages/core-api/src/modules/scoring/rollup/standings-rollup.ts
+++ b/packages/core-api/src/modules/scoring/rollup/standings-rollup.ts
@@ -1,6 +1,19 @@
 /**
- * StandingsRollup — periodic job that reads contest totals and persists
- * standings positions back onto ContestEntry.
+ * StandingsRollup — pure rerank-and-publish helper for a single contest.
+ *
+ * pool-master-rop.78.8 — the periodic interval scheduler was retired
+ * here. Per plans/117 §11.3 the substrate's single write path is
+ * event-driven: `LiveScorePersistedEvent → LiveScoreConsumer →
+ * scoring → contributions → totalScore → standingsRollup.rollupContest →
+ * standings.updated`. The full-recalculation path
+ * (ContestScoringRecalculationService) stays for explicit triggers
+ * (admin override, contest reopen) but is no longer a parallel update
+ * mechanism that races with stat-event scoring.
+ *
+ * The remaining surface is `rollupContest(contestId, options?)` —
+ * called by the live-score consumer (golf-roster) and the explicit
+ * recalculation path. `previousRanks` is kept so the per-contest
+ * rerank can report `rankChanges` accurately across successive events.
  */
 
 import type { PrismaClient } from '@prisma/client';
@@ -51,12 +64,8 @@ export interface StandingsRollupDeps {
 
 // --- Rollup Class ---
 
-const DEFAULT_INTERVAL_MS = 30_000;
-
 /** Reads current totals, assigns ranks, and persists standings to ContestEntry. */
 export class StandingsRollup {
-  private intervalHandle: ReturnType<typeof setInterval> | null = null;
-  private activeContestIds: Set<string> = new Set();
   private previousRanks: Map<string, Map<string, number>> = new Map();
   private readonly eventBus: EventBus;
   private readonly prisma: PrismaClient;
@@ -66,17 +75,6 @@ export class StandingsRollup {
     this.eventBus = deps.eventBus;
     this.prisma = deps.prisma;
     this.logger = deps.logger;
-  }
-
-  /** Register a contest for periodic rollup. */
-  registerContest(contestId: string): void {
-    this.activeContestIds.add(contestId);
-  }
-
-  /** Unregister a contest from periodic rollup. */
-  unregisterContest(contestId: string): void {
-    this.activeContestIds.delete(contestId);
-    this.previousRanks.delete(contestId);
   }
 
   /** Run rollup for a specific contest. */
@@ -100,55 +98,16 @@ export class StandingsRollup {
     await this.persistStandings(contestId, standings, rolledUpAt);
 
     await this.publishStandingsUpdated(contestId, standings, rolledUpAt);
+    this.logger?.debug?.(
+      { action: 'scoring.standings_rollup.rollup', data: { contestId, entriesUpdated: standings.length, rankChanges } },
+      'Reranked contest standings',
+    );
     return {
       contestId,
       entriesUpdated: standings.length,
       rankChanges,
       rolledUpAt,
     };
-  }
-
-  /** Run rollup for all registered active contests. */
-  async rollupAll(): Promise<RollupResult[]> {
-    const results: RollupResult[] = [];
-    for (const contestId of this.activeContestIds) {
-      const result = await this.rollupContest(contestId);
-      results.push(result);
-    }
-    return results;
-  }
-
-  /** Start periodic rollup at the given interval. */
-  startPeriodicRollup(intervalMs: number = DEFAULT_INTERVAL_MS): void {
-    if (this.intervalHandle) return;
-    this.intervalHandle = setInterval(() => {
-      this.rollupAll().catch((err) => {
-        this.logger?.error({
-          action: 'scoring.standings_rollup.periodic_failed',
-          err,
-          data: {
-            activeContestCount: this.activeContestIds.size,
-          },
-        }, 'Periodic standings rollup failed');
-      });
-    }, intervalMs);
-  }
-
-  /** Stop periodic rollup. */
-  stopPeriodicRollup(): void {
-    if (!this.intervalHandle) return;
-    clearInterval(this.intervalHandle);
-    this.intervalHandle = null;
-  }
-
-  /** Check if periodic rollup is running. */
-  isRunning(): boolean {
-    return this.intervalHandle !== null;
-  }
-
-  /** Get the set of active contest IDs. */
-  getActiveContestIds(): ReadonlySet<string> {
-    return this.activeContestIds;
   }
 
   /** Persist standings positions onto ContestEntry. */

--- a/packages/core-api/src/modules/scoring/service.ts
+++ b/packages/core-api/src/modules/scoring/service.ts
@@ -68,8 +68,15 @@ export interface ParticipantScoreHistory {
 export interface HealthDetail {
   status: 'ok';
   service: string;
-  rollupRunning: boolean;
-  activeContests: number;
+  /**
+   * Indicates the live-score-driven scoring path is the canonical
+   * single write path (plans/117 §11.3). Always true in this build —
+   * pool-master-rop.78.8 retired the periodic rollup interval so there
+   * is no longer a separate "rollup running" lifecycle to surface. The
+   * field is kept on the response so existing health consumers can
+   * continue to call the endpoint without a contract change.
+   */
+  eventDriven: true;
   timestamp: string;
 }
 
@@ -269,14 +276,10 @@ export class ScoringService {
     const detail: HealthDetail = {
       status: 'ok',
       service: 'scoring-service',
-      rollupRunning: this.standingsRollup.isRunning(),
-      activeContests: this.standingsRollup.getActiveContestIds().size,
+      eventDriven: true,
       timestamp: new Date().toISOString(),
     };
-    this.logger?.debug({
-      rollupRunning: detail.rollupRunning,
-      activeContests: detail.activeContests,
-    }, 'Read scoring service health');
+    this.logger?.debug({ eventDriven: detail.eventDriven }, 'Read scoring service health');
     return detail;
   }
 }

--- a/packages/shared/dto/scoring.dto.ts
+++ b/packages/shared/dto/scoring.dto.ts
@@ -87,8 +87,11 @@ export type RollupResultResponse = z.infer<typeof RollupResultResponseSchema>;
 export const ScoringHealthResponseSchema = z.object({
   status: z.literal('ok'),
   service: z.string(),
-  rollupRunning: z.boolean(),
-  activeContests: z.number(),
+  eventDriven: z.literal(true).describe(
+    'Always true: the scoring path is event-driven via live_score.persisted '
+    + '(plans/117 §11.3). The legacy `rollupRunning` / `activeContests` fields '
+    + 'were removed in pool-master-rop.78.8 along with the periodic rollup interval.',
+  ),
   timestamp: z.string().datetime().describe('When the scoring-health snapshot was recorded.'),
 }).describe('Scoring-service health response.');
 export type ScoringHealthResponse = z.infer<typeof ScoringHealthResponseSchema>;

--- a/packages/shared/generated/api-types.ts
+++ b/packages/shared/generated/api-types.ts
@@ -20620,8 +20620,11 @@ export interface operations {
                         /** @enum {string} */
                         status: "ok";
                         service: string;
-                        rollupRunning: boolean;
-                        activeContests: number;
+                        /**
+                         * @description Always true: the scoring path is event-driven via live_score.persisted (plans/117 §11.3). The legacy `rollupRunning` / `activeContests` fields were removed in pool-master-rop.78.8 along with the periodic rollup interval.
+                         * @enum {boolean}
+                         */
+                        eventDriven: true;
                         /**
                          * Format: date-time
                          * @description When the scoring-health snapshot was recorded.

--- a/packages/shared/generated/hey-api/types.gen.ts
+++ b/packages/shared/generated/hey-api/types.gen.ts
@@ -20971,8 +20971,10 @@ export type GetScoringHealthResponses = {
     200: {
         status: 'ok';
         service: string;
-        rollupRunning: boolean;
-        activeContests: number;
+        /**
+         * Always true: the scoring path is event-driven via live_score.persisted (plans/117 §11.3). The legacy `rollupRunning` / `activeContests` fields were removed in pool-master-rop.78.8 along with the periodic rollup interval.
+         */
+        eventDriven: true;
         /**
          * When the scoring-health snapshot was recorded.
          */

--- a/packages/shared/generated/openapi.json
+++ b/packages/shared/generated/openapi.json
@@ -43783,11 +43783,12 @@
                     "service": {
                       "type": "string"
                     },
-                    "rollupRunning": {
-                      "type": "boolean"
-                    },
-                    "activeContests": {
-                      "type": "number"
+                    "eventDriven": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ],
+                      "description": "Always true: the scoring path is event-driven via live_score.persisted (plans/117 §11.3). The legacy `rollupRunning` / `activeContests` fields were removed in pool-master-rop.78.8 along with the periodic rollup interval."
                     },
                     "timestamp": {
                       "type": "string",
@@ -43798,8 +43799,7 @@
                   "required": [
                     "status",
                     "service",
-                    "rollupRunning",
-                    "activeContests",
+                    "eventDriven",
                     "timestamp"
                   ],
                   "additionalProperties": false,

--- a/tests/integration/core-api/scoring-read.integration.ts
+++ b/tests/integration/core-api/scoring-read.integration.ts
@@ -57,12 +57,14 @@ describe('Scoring Read Integration', () => {
       headers: user.headers,
     });
     expect(healthRes.statusCode).toBe(200);
+    // pool-master-rop.78.8 — periodic StandingsRollup retired; the
+    // health response no longer carries `rollupRunning` / `activeContests`
+    // and surfaces `eventDriven: true` instead.
     expect(healthRes.json()).toEqual(
       expect.objectContaining({
         status: 'ok',
         service: 'scoring-service',
-        rollupRunning: expect.any(Boolean),
-        activeContests: expect.any(Number),
+        eventDriven: true,
       }),
     );
   });

--- a/tests/integration/core-api/scoring-read.integration.ts
+++ b/tests/integration/core-api/scoring-read.integration.ts
@@ -59,14 +59,20 @@ describe('Scoring Read Integration', () => {
     expect(healthRes.statusCode).toBe(200);
     // pool-master-rop.78.8 — periodic StandingsRollup retired; the
     // health response no longer carries `rollupRunning` / `activeContests`
-    // and surfaces `eventDriven: true` instead.
-    expect(healthRes.json()).toEqual(
+    // and surfaces `eventDriven: true` instead. The route-level contract
+    // assertion has to lock both halves of that change: the new field is
+    // present AND the retired fields are gone (objectContaining-only would
+    // still pass if the real HTTP response kept returning the legacy keys).
+    const body = healthRes.json();
+    expect(body).toEqual(
       expect.objectContaining({
         status: 'ok',
         service: 'scoring-service',
         eventDriven: true,
       }),
     );
+    expect(body).not.toHaveProperty('rollupRunning');
+    expect(body).not.toHaveProperty('activeContests');
   });
 
   it('pool-master-rop.6: serves scoring reads and returns 404 for missing entry breakdowns', async () => {

--- a/tests/unit/core-api/scoring-service.test.ts
+++ b/tests/unit/core-api/scoring-service.test.ts
@@ -5,8 +5,6 @@ describe('ScoringService', () => {
   it('pool-master-rop.6: throws when the entry is missing or belongs to another contest', async () => {
     const standingsRollup = {
       rollupContest: jest.fn(),
-      isRunning: jest.fn().mockReturnValue(false),
-      getActiveContestIds: jest.fn().mockReturnValue(new Set()),
     };
     const prisma = {
       contestEntry: {
@@ -37,8 +35,6 @@ describe('ScoringService', () => {
   it('reads persisted entry scoring events from the participant score ledger', async () => {
     const standingsRollup = {
       rollupContest: jest.fn(),
-      isRunning: jest.fn().mockReturnValue(false),
-      getActiveContestIds: jest.fn().mockReturnValue(new Set()),
     };
     const prisma = {
       contestEntry: {
@@ -128,8 +124,6 @@ describe('ScoringService', () => {
     const service = new ScoringService({
       standingsRollup: {
         rollupContest: jest.fn(),
-        isRunning: jest.fn().mockReturnValue(false),
-        getActiveContestIds: jest.fn().mockReturnValue(new Set()),
       } as any,
       prisma,
     });
@@ -162,8 +156,6 @@ describe('ScoringService', () => {
     const service = new ScoringService({
       standingsRollup: {
         rollupContest: jest.fn(),
-        isRunning: jest.fn().mockReturnValue(false),
-        getActiveContestIds: jest.fn().mockReturnValue(new Set()),
       } as any,
       prisma: {
         contestEntryParticipantScoreEvent: {
@@ -187,8 +179,6 @@ describe('ScoringService', () => {
         entriesUpdated: 3,
         leaderboardChanged: true,
       }),
-      isRunning: jest.fn().mockReturnValue(true),
-      getActiveContestIds: jest.fn().mockReturnValue(new Set(['contest-1', 'contest-2'])),
     };
     const service = new ScoringService({
       standingsRollup: standingsRollup as any,
@@ -201,13 +191,18 @@ describe('ScoringService', () => {
       leaderboardChanged: true,
     });
     expect(standingsRollup.rollupContest).toHaveBeenCalledWith('contest-1');
-    expect(service.getHealth()).toEqual(
+    // pool-master-rop.78.8 — periodic rollup retired. The health response
+    // surfaces eventDriven: true (always) and no longer carries
+    // rollupRunning / activeContests.
+    const health = service.getHealth();
+    expect(health).toEqual(
       expect.objectContaining({
         status: 'ok',
         service: 'scoring-service',
-        rollupRunning: true,
-        activeContests: 2,
+        eventDriven: true,
       }),
     );
+    expect(health).not.toHaveProperty('rollupRunning');
+    expect(health).not.toHaveProperty('activeContests');
   });
 });

--- a/tests/unit/scoring-service/scoring-pipeline-errors.test.ts
+++ b/tests/unit/scoring-service/scoring-pipeline-errors.test.ts
@@ -231,27 +231,27 @@ describe('scoreParticipant with missing stat keys', () => {
 });
 
 // ========================================================================
-// 12. StandingsRollup.rollupContest — no registered contests
+// 12. StandingsRollup — periodic-mode surface retired (pool-master-rop.78.8)
 // ========================================================================
 
-describe('StandingsRollup error paths', () => {
-  it('rollupAll returns empty results when no contests are registered', async () => {
-    const eventBus = new EventBus();
-    const mockPrisma = {
-      contestEntry: {
-        findMany: jest.fn(),
-      },
-    } as any;
-
+describe('StandingsRollup periodic-mode surface (retired in rop.78.8)', () => {
+  it('does not expose `rollupAll` / periodic scheduler methods', () => {
+    // Pre-rop.78.8 the rollup ran on a 30s setInterval and had a
+    // `rollupAll` / `startPeriodicRollup` / `stopPeriodicRollup` /
+    // `isRunning` / `getActiveContestIds` / `registerContest` /
+    // `unregisterContest` surface. Plans/117 §11.3 retired the periodic
+    // path so the substrate has a single event-driven write path.
     const rollup = new StandingsRollup({
-      eventBus,
-      prisma: mockPrisma,
+      eventBus: new EventBus(),
+      prisma: { contestEntry: { findMany: jest.fn() } } as any,
     });
 
-    // No contests registered — rollupAll should complete gracefully
-    const results = await rollup.rollupAll();
-
-    expect(results).toEqual([]);
-    expect(mockPrisma.contestEntry.findMany).not.toHaveBeenCalled();
+    expect(rollup).not.toHaveProperty('rollupAll');
+    expect(rollup).not.toHaveProperty('startPeriodicRollup');
+    expect(rollup).not.toHaveProperty('stopPeriodicRollup');
+    expect(rollup).not.toHaveProperty('isRunning');
+    expect(rollup).not.toHaveProperty('getActiveContestIds');
+    expect(rollup).not.toHaveProperty('registerContest');
+    expect(rollup).not.toHaveProperty('unregisterContest');
   });
 });


### PR DESCRIPTION
## Summary

Phase 4 scoring concurrency closeout for `pool-master-rop.78` per [plans/117 §11.3, §11.4, §11.5](../blob/main/plans/117-league-contest-substrate-redesign.md). Folds in `pool-master-rop.7`, `.8`, `.11`, `.12` (all symptoms of no per-contest concurrency control).

Most of this slice's design intent shipped earlier:

- **Per-contest `pg_try_advisory_xact_lock`** for scoring transactions (audit Q4) — shipped in `rop.78.7`'s `LiveScoreConsumer`.
- **One transaction per (contest, stat event)** — score → contribution → rerank atomic (audit Q6) — also `rop.78.7`.

This slice closes the remaining piece: **kill the periodic StandingsRollup** so the event-driven path is the canonical single write path (audit Q5).

## Files

**StandingsRollup** (`packages/core-api/src/modules/scoring/rollup/standings-rollup.ts`)

- Drop `intervalHandle` / `activeContestIds` / `DEFAULT_INTERVAL_MS` state.
- Drop the seven periodic-mode methods: `startPeriodicRollup` / `stopPeriodicRollup` / `isRunning` / `rollupAll` / `registerContest` / `unregisterContest` / `getActiveContestIds`.
- Keep `rollupContest(contestId, options?)` — the only canonical entry point now (live-score consumer + ContestScoringRecalculationService both call it).
- Keep `previousRanks` so rerank reports accurate `rankChanges` across successive events.

**App wire-up** (`packages/core-api/src/index.ts`)

- Drop `standingsRollup.startPeriodicRollup()` from the startup block.
- Replace `standingsRollup.stopPeriodicRollup()` in the `onClose` hook with `liveScoreConsumer.unsubscribe()` so the event subscription is torn down cleanly on Fastify shutdown.

**Scoring health response** (`HealthDetail` + `ScoringHealthResponseSchema`)

- Drop `rollupRunning: boolean` and `activeContests: number` (both derived from the retired periodic-mode state).
- Add `eventDriven: true` literal so existing health consumers see a non-empty field and the substrate's contract is documented in the response shape.
- Regenerate `packages/shared/generated/openapi.json`, `hey-api/types.gen.ts`, and `api-types.ts`.

**ContestScoringRecalculationService** — unchanged. Per plans/117 §11.3 it remains the explicit-trigger path (admin override / contest reopen) but is no longer a parallel update mechanism that races with stat-event scoring.

## Defect / slice proof

`tests/unit/scoring-service/scoring-pipeline-errors.test.ts` — replaces the prior `rollupAll` smoke test with a structural defect-proof block asserting `StandingsRollup` no longer exposes the seven retired periodic-mode methods (`rollupAll`, `startPeriodicRollup`, `stopPeriodicRollup`, `isRunning`, `getActiveContestIds`, `registerContest`, `unregisterContest`). Every assertion fails on `origin/main` where those methods exist.

`tests/unit/core-api/scoring-service.test.ts` — the "health state" case now asserts `eventDriven: true` and `not.toHaveProperty('rollupRunning')` / `not.toHaveProperty('activeContests')` so the response-shape change is regression-locked.

## Verification

- `npx turbo typecheck --force` — PASS (6/6)
- `npx eslint 'packages/*/src/**/*.ts' --max-warnings 0` — PASS
- `npx jest --config tests/jest.config.js tests/unit --runInBand --forceExit` — PASS (656 passed, 1 skipped — 7 structural assertions added, 2 health-state assertions updated)
- `npm run api:refresh` — PASS, scoring-health shape regenerated

## Riley findings

<!-- riley:findings -->
No findings. The deletion is contained: the seven retired methods are gone, the seven structural assertions confirm it, the health response gets a typed replacement field (`eventDriven: true`) so consumers can detect the new contract, and the only remaining `rollupContest` callers (live-score consumer for golf-roster, ContestScoringRecalculationService for explicit triggers) both still typecheck and pass their existing tests. Plans/117 §11.3's "no periodic rollup" decision is now the runtime behavior; the explicit recalc path stays exactly where the design left it.
