### PR TITLE
[pool-master-rop.76.2] Remove literal JWT placeholders from committed files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,12 @@
 # === Auth ===
 # JWT signing key. Required at startup — the bootstrap throws if unset
 # (see packages/core-api/src/core/config.ts; pool-master-rop.76.1).
-# This placeholder is for local dev only. Production must set the
-# variable via the deployment's secret manager (e.g., AWS Secrets
-# Manager → ECS task `secrets` block, K8s Secret mounted as env).
-JWT_SECRET=poolmaster-dev-secret-change-in-production
+# Generate a value yourself; do NOT commit it. Suggested:
+#   openssl rand -base64 48 | tr -d '\n'
+# Production must set the variable via the deployment's secret manager
+# (AWS Secrets Manager → ECS task `secrets` block, K8s Secret mounted
+# as env, etc.) — never via a committed file.
+JWT_SECRET=
 
 # === Database ===
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/poolmaster

--- a/infrastructure/terraform/envs/prod.tfvars.example
+++ b/infrastructure/terraform/envs/prod.tfvars.example
@@ -7,11 +7,11 @@ region      = "us-east-2"
 db_instance_class    = "db.t3.small"
 db_allocated_storage = 50
 db_password          = "CHANGE_ME_strong_prod_password"
-# jwt_secret: do NOT set here. Set via TF_VAR_jwt_secret in your shell or
-# read from your secrets vault — the value must never land in a committed
-# file. Generate with:
-#   openssl rand -base64 48 | tr -d '\n'
-jwt_secret           = ""
+# jwt_secret: deliberately not assigned in this file. Set via TF_VAR_jwt_secret
+# in your shell or read from your secrets vault — the value must never land in
+# a committed file. Do NOT add a `jwt_secret = "..."` line here — tfvars-file
+# precedence is higher than TF_VAR_*, so an assignment here would silently
+# override the env var. Generate with: openssl rand -base64 48 | tr -d '\n'
 
 # ECS (more resources for prod)
 ecs_cpu    = 512

--- a/infrastructure/terraform/envs/prod.tfvars.example
+++ b/infrastructure/terraform/envs/prod.tfvars.example
@@ -7,7 +7,11 @@ region      = "us-east-2"
 db_instance_class    = "db.t3.small"
 db_allocated_storage = 50
 db_password          = "CHANGE_ME_strong_prod_password"
-jwt_secret           = "CHANGE_ME_strong_prod_jwt_secret"
+# jwt_secret: do NOT set here. Set via TF_VAR_jwt_secret in your shell or
+# read from your secrets vault — the value must never land in a committed
+# file. Generate with:
+#   openssl rand -base64 48 | tr -d '\n'
+jwt_secret           = ""
 
 # ECS (more resources for prod)
 ecs_cpu    = 512

--- a/infrastructure/terraform/envs/qa.tfvars.example
+++ b/infrastructure/terraform/envs/qa.tfvars.example
@@ -7,10 +7,11 @@ region      = "us-east-2"
 db_instance_class    = "db.t3.micro"
 db_allocated_storage = 20
 db_password          = "CHANGE_ME_qa_password"
-# jwt_secret: do NOT set here. Set via TF_VAR_jwt_secret in your shell so
-# the value never lands in a committed file. Generate with:
-#   openssl rand -base64 48 | tr -d '\n'
-jwt_secret           = ""
+# jwt_secret: deliberately not assigned in this file. Set via TF_VAR_jwt_secret
+# in your shell so the value never lands in a committed file. Do NOT add a
+# `jwt_secret = "..."` line here — tfvars-file precedence is higher than
+# TF_VAR_*, so an assignment here would silently override the env var.
+# Generate with: openssl rand -base64 48 | tr -d '\n'
 db_publicly_accessible = true
 db_allowed_cidr_blocks = ["YOUR_PUBLIC_IP/32"]
 

--- a/infrastructure/terraform/envs/qa.tfvars.example
+++ b/infrastructure/terraform/envs/qa.tfvars.example
@@ -7,7 +7,10 @@ region      = "us-east-2"
 db_instance_class    = "db.t3.micro"
 db_allocated_storage = 20
 db_password          = "CHANGE_ME_qa_password"
-jwt_secret           = "CHANGE_ME_qa_jwt_secret"
+# jwt_secret: do NOT set here. Set via TF_VAR_jwt_secret in your shell so
+# the value never lands in a committed file. Generate with:
+#   openssl rand -base64 48 | tr -d '\n'
+jwt_secret           = ""
 db_publicly_accessible = true
 db_allowed_cidr_blocks = ["YOUR_PUBLIC_IP/32"]
 

--- a/infrastructure/terraform/envs/staging.tfvars.example
+++ b/infrastructure/terraform/envs/staging.tfvars.example
@@ -7,10 +7,11 @@ region      = "us-east-2"
 db_instance_class    = "db.t3.micro"
 db_allocated_storage = 20
 db_password          = "CHANGE_ME_staging_password"
-# jwt_secret: do NOT set here. Set via TF_VAR_jwt_secret in your shell so
-# the value never lands in a committed file. Generate with:
-#   openssl rand -base64 48 | tr -d '\n'
-jwt_secret           = ""
+# jwt_secret: deliberately not assigned in this file. Set via TF_VAR_jwt_secret
+# in your shell so the value never lands in a committed file. Do NOT add a
+# `jwt_secret = "..."` line here — tfvars-file precedence is higher than
+# TF_VAR_*, so an assignment here would silently override the env var.
+# Generate with: openssl rand -base64 48 | tr -d '\n'
 
 # ECS
 ecs_cpu    = 256

--- a/infrastructure/terraform/envs/staging.tfvars.example
+++ b/infrastructure/terraform/envs/staging.tfvars.example
@@ -7,7 +7,10 @@ region      = "us-east-2"
 db_instance_class    = "db.t3.micro"
 db_allocated_storage = 20
 db_password          = "CHANGE_ME_staging_password"
-jwt_secret           = "CHANGE_ME_staging_jwt_secret"
+# jwt_secret: do NOT set here. Set via TF_VAR_jwt_secret in your shell so
+# the value never lands in a committed file. Generate with:
+#   openssl rand -base64 48 | tr -d '\n'
+jwt_secret           = ""
 
 # ECS
 ecs_cpu    = 256

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -79,9 +79,14 @@ variable "db_password" {
 }
 
 variable "jwt_secret" {
-  description = "JWT signing key for the core-api. Required — set via TF_VAR_jwt_secret or tfvars. The previous deterministic dev fallback in source code was removed in pool-master-rop.76.1; the core-api throws at startup if the env var is unset, so this value MUST be supplied for any environment where the API actually runs."
+  description = "JWT signing key for the core-api. Required — set via TF_VAR_jwt_secret or an untracked tfvars file. The previous deterministic dev fallback in source code was removed in pool-master-rop.76.1; the core-api throws at startup if the env var is unset. Generate with: openssl rand -base64 48 | tr -d '\\n'."
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.jwt_secret)) > 0
+    error_message = "jwt_secret is required and must be non-empty. Generate with: openssl rand -base64 48 | tr -d '\\n'. Recommended minimum 32 characters for production. Do NOT commit the value — set it via TF_VAR_jwt_secret or an untracked tfvars file."
+  }
 }
 
 variable "db_publicly_accessible" {


### PR DESCRIPTION
## Summary

Follow-up to **`pool-master-rop.76.1`** (#38). The original fix removed the in-source `?? 'poolmaster-dev-secret-change-in-production'` fallback from the three core-api call sites and added a `rules:check:no-env-fallbacks` scanner — but it **left literal placeholder strings in committed example files**: `JWT_SECRET=poolmaster-dev-secret-change-in-production` in `.env.example`, and `jwt_secret = "CHANGE_ME_<env>_jwt_secret"` in `envs/{qa,staging,prod}.tfvars.example`. An operator who copied an example file as-is would still be running on a value pulled straight from the repo — the same anti-pattern the in-source fallback represented, with a different file extension.

After this PR, the repo contains **zero literal JWT signing strings** across all environments.

## Changes

- **`.env.example`** — `JWT_SECRET=` is now blank, with a comment pointing at `openssl rand -base64 48 | tr -d '\n'`. The bootstrap (introduced in 76.1) throws on empty, so a developer who forgets to set the value gets a clear startup error instead of silently using a known key.
- **`infrastructure/terraform/envs/{qa,staging,prod}.tfvars.example`** — `jwt_secret` is **not assigned** in these files. The assignment is removed entirely (not commented out, not set to empty string) so it does not override the operator's exported `TF_VAR_jwt_secret`. The comment block explains how to set the value AND warns about the tfvars-file > TF_VAR_* precedence trap.
- **`infrastructure/terraform/variables.tf`** — added a `validation` block on `var.jwt_secret`:
  ```hcl
  validation {
    condition     = length(trimspace(var.jwt_secret)) > 0
    error_message = "jwt_secret is required and must be non-empty. Generate with: openssl rand -base64 48 | tr -d '\\n'. Recommended minimum 32 characters for production. Do NOT commit the value — set it via TF_VAR_jwt_secret or an untracked tfvars file."
  }
  ```
  Catches "operator forgot to set TF_VAR_jwt_secret" at `terraform plan` time with a clear message, instead of at `apply` time with a cryptic AWS API rejection on an empty `secret_string`.

## Why a non-empty validation, not a 32-char minimum

The hard footgun this PR closes is **using a value that came from the repo**. A length floor would also be nice for entropy, but it would reject existing operator-chosen values that happen to be shorter than 32 chars. The recommendation is in the description and error message; environments that want to enforce a length floor can tighten the validation in a follow-up. For QA / staging this is acceptable; production is documented to use 32+ characters.

## Why removing the assignment vs. assigning empty string

Original push of this branch had `jwt_secret = ""` in each tfvars example. Riley flagged that this silently overrides an exported `TF_VAR_jwt_secret` because Terraform's variable precedence puts `-var-file` above `TF_VAR_*`. Removing the line entirely (and warning operators in the comment NOT to re-add it) is the correct fix — copying the example to a working tfvars now leaves `jwt_secret` unset in the file, the env var takes effect, and validation passes when the env var is set.

## Verification

- `terraform fmt -check -recursive` — PASS
- `terraform validate` — PASS (`Success! The configuration is valid.`)
- `npm run rules:check` — PASS (all scanners including `rules:check:no-env-fallbacks`)
- Manual: `grep -rn 'poolmaster-dev-secret-change-in-production\|CHANGE_ME_.*jwt_secret' .` — no matches

## Operational impact

None. The bootstrap behavior is unchanged: `readJwtSecret()` still reads `process.env.JWT_SECRET` at startup and throws on missing/empty. Operators with an existing un-tracked `qa.tfvars` (or `TF_VAR_jwt_secret` exported in their shell) keep working without changes. The validation only fires when the variable would have been empty, which is exactly the case this PR exists to catch.

## Riley findings

<!-- riley:findings -->

Two P1s flagged on the original push, both addressed in 07a22561:

1. **`jwt_secret = ""` would override `TF_VAR_jwt_secret`** — correct. Terraform's `-var-file` precedence is above `TF_VAR_*`, so the empty string in the example would have failed validation even when the operator did the right thing. Fixed by removing the assignment entirely from all three tfvars examples; comment now warns against re-adding it.
2. **Missing `<!-- riley:findings -->` marker in PR body** — fixed in this body update.

**Open question on `db_password`:** Riley noted the same operator-copy footgun applies to `db_password = "CHANGE_ME_*"` in the same files. Out of scope for this slice — db_password rotation has a wider blast radius (RDS rotation involves brief connectivity disruption) and deserves its own slice with a separate verification plan. Tracking as a follow-up; not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)