### PR TITLE
[pool-master-rop.78.13.1] Fix publish-images CI: link mock-contest-feed-provider workspace in Dockerfile.core-api

### DIFF
--- a/infrastructure/docker/Dockerfile.core-api
+++ b/infrastructure/docker/Dockerfile.core-api
@@ -3,6 +3,7 @@ WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.base.json ./
 COPY packages/shared/ ./packages/shared/
+COPY packages/mock-contest-feed-provider/ ./packages/mock-contest-feed-provider/
 COPY packages/core-api/ ./packages/core-api/
 
 RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
@@ -10,8 +11,13 @@ RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
 # Build shared package
 RUN cd packages/shared && npx tsc
 
-# Symlink shared into node_modules for runtime resolution
-RUN mkdir -p node_modules/@poolmaster && ln -sf /app/packages/shared node_modules/@poolmaster/shared
+# Symlink workspace packages into node_modules for resolution.
+# core-api imports type-only from @poolmaster/mock-contest-feed-provider/generated/hey-api/types
+# (see packages/core-api/src/modules/ingestion/adapters/mock-contest-feed-adapter.ts), so the
+# package must be resolvable at tsc time even though no runtime require is emitted.
+RUN mkdir -p node_modules/@poolmaster \
+    && ln -sf /app/packages/shared node_modules/@poolmaster/shared \
+    && ln -sf /app/packages/mock-contest-feed-provider node_modules/@poolmaster/mock-contest-feed-provider
 
 # Generate Prisma client
 RUN npx prisma generate --schema=packages/core-api/prisma/schema.prisma
@@ -28,7 +34,10 @@ COPY --from=base /app/packages/core-api/package.json ./
 COPY --from=base /app/packages/core-api/scripts ./scripts
 COPY --from=base /app/node_modules ./node_modules
 COPY --from=base /app/packages/shared ./packages/shared
-RUN mkdir -p node_modules/@poolmaster && ln -sf /app/packages/shared node_modules/@poolmaster/shared
+COPY --from=base /app/packages/mock-contest-feed-provider ./packages/mock-contest-feed-provider
+RUN mkdir -p node_modules/@poolmaster \
+    && ln -sf /app/packages/shared node_modules/@poolmaster/shared \
+    && ln -sf /app/packages/mock-contest-feed-provider node_modules/@poolmaster/mock-contest-feed-provider
 COPY --from=base /app/packages/core-api/prisma ./prisma
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary

The **publish-images** CI job has been failing on every push to main since **2026-05-07 16:36** when [pool-master-rop.78.13](https://github.com/derek-dorazio/pool-master/pull/32) merged. That PR introduced a cross-workspace import in core-api but didn't update the Dockerfile to link the new dependency:

```ts
// packages/core-api/src/modules/ingestion/adapters/mock-contest-feed-adapter.ts:25
import type {
  ListMockContestFeedScenariosResponse,
  // ...
} from '@poolmaster/mock-contest-feed-provider/generated/hey-api/types';
```

`Dockerfile.core-api` only copies and symlinks `@poolmaster/shared` as a workspace — not `@poolmaster/mock-contest-feed-provider`. The Dockerfile's own `npx tsc` step then errors with `TS2307: Cannot find module '@poolmaster/mock-contest-feed-provider/generated/hey-api/types'`, plus a cascade of TS7006 (implicit-any) errors that follow from the unresolved types.

`turbo typecheck` and the standalone `lint-and-typecheck` CI job both pass because they read the real workspace setup. Only the Dockerfile build environment is missing the package link.

## Blast radius today

Eight merges-to-main have happened on top of this break with **no images pushed to ECR**. The newest `:bootstrap` tag in ECR is from `7e48863` (pool-master-rop.78.7, pushed 16:33 — before this break landed). That includes:

- pool-master-rop.78.13 — the PR that introduced the break
- pool-master-rop.78.8, .12, plus PRs #31, #34, #35, #37
- **pool-master-rop.76.1** — JWT_SECRET single bootstrap source (the fix that removed the `??` fallback)
- **pool-master-rop.76.2** — JWT placeholder cleanup

Knock-on effect on the rop.76.1 deploy: `terraform apply` succeeded and created the Secrets Manager secret + IAM policy + task definition `:249` (with the `secrets` block injecting `JWT_SECRET`), but the new task can't start because it pulls `image: ...:bootstrap` and that image hasn't been refreshed since before the rop.76.1 code landed. The QA core-api is stuck on task def `:247` running an old image digest that pre-dates the JWT bootstrap fix. Restoring publish-images is the prerequisite for that fix to actually run in QA.

## Fix

Mirror the `@poolmaster/shared` pattern for `mock-contest-feed-provider` in both the build and runtime stages of `Dockerfile.core-api`:

1. **Build stage:** `COPY packages/mock-contest-feed-provider/` and add a workspace symlink in `node_modules/@poolmaster/`.
2. **Runtime stage:** mirror the COPY + symlink so `node_modules/@poolmaster/mock-contest-feed-provider` isn't a dangling symlink. Even though the import is type-only and no runtime require is emitted, keeping the runtime stage consistent avoids surprises if a future code path imports a value from the package.

A comment in the Dockerfile explains why mock-contest-feed-provider needs to be linked despite being type-only at the import site, so future agents don't try to remove it.

## Why this isn't part of rop.78.13

PR #32's CI ran the standalone `lint-and-typecheck` job (which uses `turbo typecheck` with the real workspace) — that passed. Feature-branch CI also runs `publish-images`, but that's where the failure actually surfaces. The merge dashboard would have shown the failure on the merged-to-main run, but multiple subsequent PRs landed without anyone diagnosing the underlying cause. Filing this as a `.13.1` follow-up under rop.78.13 since that's the slice that introduced the cross-workspace import.

## Verification

- This PR's CI run will exercise `publish-images` against the fixed Dockerfile. Green = fix confirmed.
- After merge, ECR `:bootstrap` tag is refreshed to a current image, and the QA core-api ECS service rolls forward to task definition `:249` automatically (the service has been polling for new task starts since 22:30; once the image is pullable, ECS will start the new task and drain `:247`).
- Post-deploy verification of rop.76.1 (Secrets-Manager-injected `JWT_SECRET` actually reaching the bootstrap) becomes possible after that.

## Riley findings

<!-- riley:findings -->

No findings. The fix is mechanical and minimal: it copies one workspace package into two Docker stages and adds two symlinks. The change is isolated to `Dockerfile.core-api`. The CI run on this PR is the verification — there's no behavioral surface to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)