### PR TITLE
Fix QA browser auth setup

### DIFF
--- a/clients/poolmaster/src/features/leagues/leagues-page.test.tsx
+++ b/clients/poolmaster/src/features/leagues/leagues-page.test.tsx
@@ -122,6 +122,7 @@ describe('pool-master-rop.23: WelcomePage generated DTO fixtures', () => {
     renderWelcomePage();
 
     expect(await screen.findByTestId('authenticated-landing-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('authenticated-landing')).toBeInTheDocument();
     expect(screen.getByTestId('shared-empty-state')).toBeInTheDocument();
     expect(sharedStateCalls.empty).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/clients/poolmaster/src/features/leagues/leagues-page.tsx
+++ b/clients/poolmaster/src/features/leagues/leagues-page.tsx
@@ -35,37 +35,39 @@ export function WelcomePage() {
 
   if (!leaguesQuery.data?.length) {
     return (
-      <EmptyState
-        action={
-          <>
-            <p className="mb-4 max-w-2xl text-sm text-muted-foreground">
-              Create your first league
-            </p>
-            <p className="mb-5 max-w-2xl text-sm text-muted-foreground">
-              Start by creating a private league with its own league code. Once it
-              exists, this home flow will route you directly into that league
-              context.
-            </p>
-            <Button
-              data-testid="welcome-create-league"
-              onClick={() => {
-                const nextParams = new URLSearchParams(searchParams);
-                nextParams.set('createLeague', '1');
-                setSearchParams(nextParams, { replace: true });
-              }}
-              type="button"
-            >
-              Create league
-            </Button>
-          </>
-        }
-        body="Once you create leagues, they'll appear here."
-        testId="authenticated-landing-empty"
-        title={`Welcome to Ultimate Office Pool Manager, ${formatUserName(
-          auth.user?.firstName,
-          auth.user?.lastName,
-        )}.`}
-      />
+      <div data-testid="authenticated-landing">
+        <EmptyState
+          action={
+            <>
+              <p className="mb-4 max-w-2xl text-sm text-muted-foreground">
+                Create your first league
+              </p>
+              <p className="mb-5 max-w-2xl text-sm text-muted-foreground">
+                Start by creating a private league with its own league code. Once it
+                exists, this home flow will route you directly into that league
+                context.
+              </p>
+              <Button
+                data-testid="welcome-create-league"
+                onClick={() => {
+                  const nextParams = new URLSearchParams(searchParams);
+                  nextParams.set('createLeague', '1');
+                  setSearchParams(nextParams, { replace: true });
+                }}
+                type="button"
+              >
+                Create league
+              </Button>
+            </>
+          }
+          body="Once you create leagues, they'll appear here."
+          testId="authenticated-landing-empty"
+          title={`Welcome to Ultimate Office Pool Manager, ${formatUserName(
+            auth.user?.firstName,
+            auth.user?.lastName,
+          )}.`}
+        />
+      </div>
     );
   }
 

--- a/packages/core-api/scripts/bootstrap-users.mjs
+++ b/packages/core-api/scripts/bootstrap-users.mjs
@@ -32,6 +32,7 @@ async function upsertUser(entry) {
       lastName,
       passwordHash,
       isRootAdmin,
+      isActive: true,
     },
     create: {
       email,
@@ -41,11 +42,12 @@ async function upsertUser(entry) {
       passwordHash,
       authProvider: UserAuthProvider.EMAIL,
       isRootAdmin,
+      isActive: true,
     },
-    select: { id: true, email: true, username: true, isRootAdmin: true },
+    select: { id: true, email: true, username: true, isRootAdmin: true, isActive: true },
   });
 
-  console.log(`Upserted ${user.email} (username=${user.username}, isRootAdmin=${user.isRootAdmin})`);
+  console.log(`Upserted ${user.email} (username=${user.username}, isRootAdmin=${user.isRootAdmin}, isActive=${user.isActive})`);
 }
 
 async function main() {

--- a/tests/unit/core-api/qa-bootstrap-users-script.test.ts
+++ b/tests/unit/core-api/qa-bootstrap-users-script.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(__dirname, '../../..');
+const bootstrapUsersScript = readFileSync(
+  resolve(repoRoot, 'packages/core-api/scripts/bootstrap-users.mjs'),
+  'utf8',
+);
+
+describe('pool-master-xw5.2: QA browser fixture user bootstrap', () => {
+  it('reactivates durable fixture users when repairing deployed browser accounts', () => {
+    expect(bootstrapUsersScript).toContain('isActive: true');
+    expect(bootstrapUsersScript).toContain('isActive=${user.isActive}');
+  });
+});


### PR DESCRIPTION
## Summary
- restore the stable authenticated landing test id expected by deployed browser auth setup
- make the QA test-user bootstrap reactivate durable fixture users while resetting credentials
- add focused coverage for the landing test id and bootstrap repair behavior

## Validation
- npm run test --workspace @poolmaster/poolmaster -- leagues-page.test.tsx
- npx jest --config tests/jest.config.js tests/unit/core-api/qa-bootstrap-users-script.test.ts --runInBand
- npx eslint clients/poolmaster/src/features/leagues/leagues-page.tsx clients/poolmaster/src/features/leagues/leagues-page.test.tsx --max-warnings 0
- git diff --check

## Riley findings

<!-- riley:findings -->
No findings.