### PR TITLE
Repair stale QA league fixture

### DIFF
--- a/clients/poolmaster/e2e/fixture-state.ts
+++ b/clients/poolmaster/e2e/fixture-state.ts
@@ -12,6 +12,13 @@ type LeagueDetail = {
   };
 };
 
+type AdminLeagueSummary = {
+  id: string;
+  leagueCode: string;
+  name: string;
+  isActive?: boolean;
+};
+
 export type QALeagueFixture = {
   code: string;
   id: string;
@@ -63,7 +70,62 @@ async function getLeagueByCode(page: Page): Promise<LeagueDetail | null> {
   return body.league;
 }
 
-async function createQALeague(page: Page): Promise<LeagueDetail> {
+async function getAdminQALeague(rootAdminPage: Page): Promise<AdminLeagueSummary | null> {
+  const response = await rootAdminPage.request.get(`/api/v1/leagues/code/${qaLeagueSeed.code}`);
+
+  if (response.status() === 404) {
+    return null;
+  }
+
+  if (!response.ok()) {
+    throw new Error(`QA league root-admin lookup failed: ${await errorMessage(response)}`);
+  }
+
+  const body = await parseJson(response) as { league?: AdminLeagueSummary } | null;
+  const league = body?.league;
+  if (!league) {
+    throw new Error('QA league root-admin lookup returned no league payload.');
+  }
+
+  if (league.leagueCode !== qaLeagueSeed.code || league.name !== qaLeagueSeed.name) {
+    throw new Error(`Refusing to repair unexpected QA league payload for ${qaLeagueSeed.code}.`);
+  }
+
+  return league;
+}
+
+async function deleteAdminQALeague(rootAdminPage: Page, league: AdminLeagueSummary) {
+  if (league.isActive !== false) {
+    const inactivateResponse = await rootAdminPage.request.post(`/api/v1/admin/leagues/${league.id}/inactivate`, {
+      headers: await csrfHeaders(rootAdminPage),
+    });
+
+    if (!inactivateResponse.ok()) {
+      throw new Error(`QA league root-admin inactivation failed: ${await errorMessage(inactivateResponse)}`);
+    }
+  }
+
+  const deleteResponse = await rootAdminPage.request.delete(`/api/v1/admin/leagues/${league.id}`, {
+    data: { leagueCode: qaLeagueSeed.code },
+    headers: await csrfHeaders(rootAdminPage),
+  });
+
+  if (!deleteResponse.ok()) {
+    throw new Error(`QA league root-admin deletion failed: ${await errorMessage(deleteResponse)}`);
+  }
+}
+
+async function repairConflictingQALeague(rootAdminPage: Page): Promise<boolean> {
+  const league = await getAdminQALeague(rootAdminPage);
+  if (!league) {
+    return false;
+  }
+
+  await deleteAdminQALeague(rootAdminPage, league);
+  return true;
+}
+
+async function createQALeague(page: Page, rootAdminPage: Page): Promise<LeagueDetail> {
   const response = await page.request.post('/api/v1/leagues/', {
     data: {
       name: qaLeagueSeed.name,
@@ -77,6 +139,10 @@ async function createQALeague(page: Page): Promise<LeagueDetail> {
     const existing = await getLeagueByCode(page);
     if (existing) {
       return existing;
+    }
+
+    if (await repairConflictingQALeague(rootAdminPage)) {
+      return createQALeague(page, rootAdminPage);
     }
   }
 
@@ -144,10 +210,11 @@ async function acceptInvite(page: Page, inviteCode: string) {
 export async function ensureQALeague(
   commissionerPage: Page,
   memberPage: Page,
+  rootAdminPage: Page,
 ): Promise<QALeagueFixture> {
   let league = await getLeagueByCode(commissionerPage);
   if (!league) {
-    league = await createQALeague(commissionerPage);
+    league = await createQALeague(commissionerPage, rootAdminPage);
   }
 
   if (!league.leagueRelationship?.commissioner) {

--- a/clients/poolmaster/e2e/fixtures.ts
+++ b/clients/poolmaster/e2e/fixtures.ts
@@ -33,8 +33,8 @@ export const test = base.extend<RoleFixtures>({
   rootAdminPage: async ({ browser }, use) => {
     await createRolePage(browser, authStatePaths.rootAdmin, use);
   },
-  qaLeague: async ({ commissionerPage, memberPage }, use) => {
-    await use(await ensureQALeague(commissionerPage, memberPage));
+  qaLeague: async ({ commissionerPage, memberPage, rootAdminPage }, use) => {
+    await use(await ensureQALeague(commissionerPage, memberPage, rootAdminPage));
   },
 });
 

--- a/tests/unit/core-api/qa-bootstrap-users-script.test.ts
+++ b/tests/unit/core-api/qa-bootstrap-users-script.test.ts
@@ -6,10 +6,27 @@ const bootstrapUsersScript = readFileSync(
   resolve(repoRoot, 'packages/core-api/scripts/bootstrap-users.mjs'),
   'utf8',
 );
+const browserFixtureState = readFileSync(
+  resolve(repoRoot, 'clients/poolmaster/e2e/fixture-state.ts'),
+  'utf8',
+);
+const browserFixtures = readFileSync(
+  resolve(repoRoot, 'clients/poolmaster/e2e/fixtures.ts'),
+  'utf8',
+);
 
 describe('pool-master-xw5.2: QA browser fixture user bootstrap', () => {
   it('reactivates durable fixture users when repairing deployed browser accounts', () => {
     expect(bootstrapUsersScript).toContain('isActive: true');
     expect(bootstrapUsersScript).toContain('isActive=${user.isActive}');
+  });
+
+  it('repairs a stale inaccessible QA fixture league before recreating it', () => {
+    expect(browserFixtures).toContain('qaLeague: async ({ commissionerPage, memberPage, rootAdminPage }, use)');
+    expect(browserFixtureState).toContain('repairConflictingQALeague(rootAdminPage)');
+    expect(browserFixtureState).toContain("rootAdminPage.request.get(`/api/v1/leagues/code/${qaLeagueSeed.code}`)");
+    expect(browserFixtureState).toContain("rootAdminPage.request.post(`/api/v1/admin/leagues/${league.id}/inactivate`");
+    expect(browserFixtureState).toContain("rootAdminPage.request.delete(`/api/v1/admin/leagues/${league.id}`");
+    expect(browserFixtureState).toContain('data: { leagueCode: qaLeagueSeed.code }');
   });
 });


### PR DESCRIPTION
## Summary
- repair stale inaccessible QATESTLEAGUE conflicts by using the root-admin browser fixture to inactivate/delete only the exact QA fixture league
- recreate the QA league through the commissioner after stale fixture cleanup so membership ownership is correct
- add focused coverage that keeps the deployed QA fixture repair path visible

## Validation
- npx eslint clients/poolmaster/e2e/fixture-state.ts clients/poolmaster/e2e/fixtures.ts --max-warnings 0
- npx jest --config tests/jest.config.js tests/unit/core-api/qa-bootstrap-users-script.test.ts --runInBand
- git diff --check

## Riley findings

<!-- riley:findings -->
No findings.