### PR TITLE
test(pool-master-cs8): provider-linked golf live-scoring + settlement FAPI scenario

### DIFF
--- a/tests/functional/golf-admin-provider-linked.functional.ts
+++ b/tests/functional/golf-admin-provider-linked.functional.ts
@@ -1,0 +1,681 @@
+import {
+  adminAutoAssignGolfPrices,
+  adminAutoAssignGolfTiers,
+  adminCreateGolfLeague,
+  adminCreateGolfSeason,
+  adminCreateGolfTournament,
+  adminGetGolfTournament,
+  adminGetGolfTournamentField,
+  adminGetGolfTournamentTiers,
+  adminLinkGolfTournamentScoreSource,
+  adminListProviderCatalogEvents,
+  adminRefreshGolfTournamentField,
+  adminReplaceGolfTournamentTiers,
+  adminSyncProviderEventData,
+  adminTransitionGolfTournament,
+  adminUnlinkGolfTournamentScoreSource,
+} from '@poolmaster/shared/generated/hey-api';
+import type { Client } from '@poolmaster/shared/generated/hey-api/client';
+import { randomUUID } from 'node:crypto';
+import { buildRegisteredUser } from './builders';
+import {
+  disconnectFunctionalPrisma,
+  expectFunctionalError,
+  getFunctionalPrisma,
+} from './setup';
+
+// plans/124 §8 — pool-master-cs8. The provider-linked half of the golf-admin
+// epic, which the flagship scenario (golf-admin-tournament.functional.ts)
+// deliberately did not cover — it drives only the manual-admin authoring +
+// clone + authz path. This scenario proves the whole provider-linked chain
+// works end to end through the real API surface, driven through the generated
+// SDK, with one real interaction with the mock contest-feed provider that the
+// FAPI daemon now runs (tests/functional/server.ts):
+//
+//   1. adminListProviderCatalogEvents — browse the mock provider's live catalog.
+//   2. adminLinkGolfTournamentScoreSource — bind a manual-admin tournament's
+//      score source to a provider event (syncScope NONE -> SCORES_ONLY);
+//      409 EXTERNAL_EVENT_ALREADY_LINKED when the event is already held.
+//   3. adminRefreshGolfTournamentField + a manual EVENTLIVESCORES sync tick —
+//      R1 scores land in SportEventParticipantGolfStanding via the sync path,
+//      never adminApplyGolfRoundScores.
+//   4. Score-sync isolation: an EVENTLIVESCORES tick never mutates the field,
+//      and an EVENTPARTICIPANTS "details" sync never mutates SportEvent.status.
+//   5. A league contest against the linked tournament settles
+//      ContestEntryGolfStanding for the sync-driven scores.
+//   6. adminUnlinkGolfTournamentScoreSource — a later sync tick does not touch
+//      the now-unlinked event's data (unlink-then-no-touch).
+//
+// UC-GOLF-ADMIN-03 (link a live score source), UC-GOLF-ADMIN-04 (sync-driven
+// live scoring + settlement), BR-GOLF-ADMIN-AUTHZ (root-admin-only ops).
+//
+// NOT covered here, and why: the "a scheduled EVENTPARTICIPANTS sweep skips a
+// SCORES_ONLY event" assertion the epic narrative mentions is a
+// scheduled-event-reader concern, not reachable through the SDK — the manual
+// event-sync endpoint deliberately *permits* EVENTPARTICIPANTS for SCORES_ONLY
+// (plans/125 §3.2; unit: admin-support-services.test.ts "pool-master-5h3").
+// The scheduled per-feed syncScope gate is covered by
+// scheduled-event-reader.test.ts "pool-master-cgb" and by
+// mock-contest-feed-provider.integration.ts "pool-master-rop.68.1.7".
+
+const MOCK_PROVIDER_ID = 'mock-contest-feed';
+// A fixed, dateable event from the static golf-major-2026 scenario — never the
+// wall-clock-relative generated scenario, so the catalog window is deterministic.
+const MOCK_EVENT_EXTERNAL_ID = 'golf-us-open-2026';
+const MOCK_EVENT_START = '2026-05-28T11:00:00.000Z';
+const MOCK_EVENT_END = '2026-05-31T22:00:00.000Z';
+const RUN = `cs8-${Date.now()}`;
+
+const created = {
+  sportEventIds: new Set<string>(),
+  seasonIds: new Set<string>(),
+  sportLeagueIds: new Set<string>(),
+  participantIds: new Set<string>(),
+  leagueIds: new Set<string>(),
+  squadIds: new Set<string>(),
+  contestIds: new Set<string>(),
+  userIds: new Set<string>(),
+};
+
+async function promoteToRootAdmin(userId: string): Promise<void> {
+  await getFunctionalPrisma().user.update({
+    where: { id: userId },
+    data: { isRootAdmin: true },
+  });
+}
+
+async function ensureGolfSportRow(): Promise<string> {
+  const sport = await getFunctionalPrisma().sport.upsert({
+    where: { name: 'GOLF' },
+    create: {
+      name: 'GOLF',
+      participantType: 'INDIVIDUAL',
+      category: 'GOLF',
+      tournamentFormat: 'STROKE_PLAY_TOURNAMENT',
+    },
+    update: {},
+  });
+  return sport.id;
+}
+
+/**
+ * Polls the provider_sync_runs ledger until the submitted async runs reach a
+ * terminal state. adminSyncProviderEventData / adminRefreshGolfTournamentField
+ * both return 202 and complete the workflow after acceptance.
+ */
+async function waitForSyncRuns(ids: string[]): Promise<void> {
+  const db = getFunctionalPrisma();
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const rows = await db.providerSyncRun.findMany({ where: { id: { in: ids } } });
+    const terminal = rows.filter((r) => r.status === 'COMPLETED' || r.status === 'FAILED');
+    if (rows.length === ids.length && terminal.length === ids.length) {
+      const failed = rows.find((r) => r.status === 'FAILED');
+      if (failed) {
+        throw new Error(`Sync run ${failed.id} FAILED: ${JSON.stringify(failed.payloadJson)}`);
+      }
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for sync runs: ${ids.join(', ')}`);
+}
+
+async function cleanup(): Promise<void> {
+  const db = getFunctionalPrisma();
+
+  const byName = await db.sportEvent.findMany({
+    where: { OR: [{ name: { contains: RUN } }, { externalId: MOCK_EVENT_EXTERNAL_ID, providerId: MOCK_PROVIDER_ID }] },
+    select: { id: true },
+  });
+  byName.forEach((e) => created.sportEventIds.add(e.id));
+  const namedLeagues = await db.sportLeague.findMany({
+    where: { name: { contains: RUN } },
+    select: { id: true },
+  });
+  namedLeagues.forEach((l) => created.sportLeagueIds.add(l.id));
+
+  const eventIds = [...created.sportEventIds];
+  const sepRows = eventIds.length
+    ? await db.sportEventParticipant.findMany({
+        where: { sportEventId: { in: eventIds } },
+        select: { id: true, participantId: true },
+      })
+    : [];
+  const sepIds = sepRows.map((r) => r.id);
+  const importedParticipantIds = new Set(sepRows.map((r) => r.participantId));
+
+  const contestIds = new Set<string>(created.contestIds);
+  if (eventIds.length) {
+    const rows = await db.contest.findMany({ where: { sportEventId: { in: eventIds } }, select: { id: true } });
+    rows.forEach((c) => contestIds.add(c.id));
+  }
+  if (contestIds.size) {
+    const cids = [...contestIds];
+    await db.draftPickHistory.deleteMany({ where: { entry: { contestId: { in: cids } } } });
+    await db.contestEntryPick.deleteMany({ where: { entry: { contestId: { in: cids } } } });
+    await db.contestEntryGolfStanding.deleteMany({ where: { contestId: { in: cids } } });
+    await db.contestEntry.deleteMany({ where: { contestId: { in: cids } } });
+    await db.draftSession.deleteMany({ where: { contestId: { in: cids } } });
+    await db.participantContestScoringRule.deleteMany({ where: { contestConfiguration: { contestId: { in: cids } } } });
+    await db.contestEntryAggregationRule.deleteMany({ where: { contestConfiguration: { contestId: { in: cids } } } });
+    await db.contestPrizeDefinition.deleteMany({ where: { contestConfiguration: { contestId: { in: cids } } } });
+    await db.contestConfiguration.deleteMany({ where: { contestId: { in: cids } } });
+    await db.contest.deleteMany({ where: { id: { in: cids } } });
+  }
+
+  if (sepIds.length) {
+    await db.contestEntryPick.deleteMany({ where: { sportEventParticipantId: { in: sepIds } } });
+    await db.sportEventParticipantGolfRound.deleteMany({ where: { sportEventParticipantId: { in: sepIds } } });
+    await db.sportEventParticipantGolfStanding.deleteMany({ where: { sportEventParticipantId: { in: sepIds } } });
+    await db.sportEventParticipantGolfValuation.deleteMany({ where: { sportEventParticipantId: { in: sepIds } } });
+    await db.sportEventParticipant.deleteMany({ where: { id: { in: sepIds } } });
+  }
+  if (eventIds.length) {
+    await db.sportEventRound.deleteMany({ where: { sportEventId: { in: eventIds } } });
+    await db.sportEventGolfTier.deleteMany({ where: { sportEventId: { in: eventIds } } });
+    await db.providerSyncRun.deleteMany({ where: { providerId: MOCK_PROVIDER_ID, eventId: MOCK_EVENT_EXTERNAL_ID } });
+    await db.ingestionJob.deleteMany({ where: { providerId: MOCK_PROVIDER_ID } });
+    await db.sportEvent.deleteMany({ where: { id: { in: eventIds } } });
+  }
+
+  const leagueIds = [...created.leagueIds];
+  if (leagueIds.length) {
+    await db.squadMembership.deleteMany({ where: { leagueId: { in: leagueIds } } });
+    await db.squad.deleteMany({ where: { leagueId: { in: leagueIds } } });
+    await db.leagueMembership.deleteMany({ where: { leagueId: { in: leagueIds } } });
+    await db.league.deleteMany({ where: { id: { in: leagueIds } } });
+  }
+
+  const sportLeagueIds = [...created.sportLeagueIds];
+  if (sportLeagueIds.length) {
+    await db.sportLeague.updateMany({ where: { id: { in: sportLeagueIds } }, data: { currentSeasonId: null } });
+  }
+  const seasonIds = new Set<string>(created.seasonIds);
+  if (sportLeagueIds.length) {
+    const extra = await db.season.findMany({ where: { sportLeagueId: { in: sportLeagueIds } }, select: { id: true } });
+    extra.forEach((s) => seasonIds.add(s.id));
+    await db.leagueEvent.deleteMany({ where: { sportLeagueId: { in: sportLeagueIds } } });
+  }
+  if (seasonIds.size) {
+    await db.season.deleteMany({ where: { id: { in: [...seasonIds] } } });
+  }
+  if (sportLeagueIds.length) {
+    await db.sportLeague.deleteMany({ where: { id: { in: sportLeagueIds } } });
+  }
+
+  const allParticipantIds = new Set<string>([...created.participantIds, ...importedParticipantIds]);
+  if (allParticipantIds.size) {
+    const pids = [...allParticipantIds];
+    await db.participantLeagueAffiliation.deleteMany({ where: { participantId: { in: pids } } });
+    await db.participantProviderMapping.deleteMany({ where: { participantId: { in: pids } } });
+    await db.participantRankingSnapshot.deleteMany({ where: { participantId: { in: pids } } });
+    await db.participant.deleteMany({
+      where: {
+        id: { in: pids },
+        sportEventParticipants: { none: {} },
+        providerMappings: { none: {} },
+      },
+    });
+  }
+
+  if (created.userIds.size) {
+    const uids = [...created.userIds];
+    await db.adminAuditEntry.deleteMany({ where: { actorId: { in: uids } } });
+    await db.refreshToken.deleteMany({ where: { userId: { in: uids } } });
+    await db.user.deleteMany({ where: { id: { in: uids } } });
+  }
+}
+
+afterAll(async () => {
+  await cleanup();
+  await disconnectFunctionalPrisma();
+});
+
+describe('SDK Functional: Golf provider-linked live scoring + settlement (pool-master-cs8, plans/124 §8)', () => {
+  it('UC-GOLF-ADMIN-03/04: browse catalog -> link -> sync-driven R1 scores -> settle -> unlink-then-no-touch', async () => {
+    await ensureGolfSportRow();
+
+    const adminCtx = await buildRegisteredUser({ displayName: 'Golf Provider Admin' });
+    created.userIds.add(adminCtx.userId);
+    await promoteToRootAdmin(adminCtx.userId);
+    const admin: Client = adminCtx.client;
+
+    // --- Tour + season -------------------------------------------------------
+    const league = await adminCreateGolfLeague({
+      client: admin,
+      body: { name: `USGA ${RUN}`, matchKeyword: 'U.S. Open' },
+    });
+    expect(league.response?.status).toBe(201);
+    const sportLeagueId = league.data!.league.id;
+    created.sportLeagueIds.add(sportLeagueId);
+
+    const season = await adminCreateGolfSeason({
+      client: admin,
+      body: {
+        sportLeagueId,
+        name: `USGA ${RUN} 2026`,
+        year: 2026,
+        startDate: '2026-04-01T00:00:00.000Z',
+        endDate: '2026-07-31T00:00:00.000Z',
+      },
+    });
+    expect(season.response?.status).toBe(201);
+    const seasonId = season.data!.season.id;
+    created.seasonIds.add(seasonId);
+
+    // --- Manual-admin tournament (starts unlinked: syncScope NONE). Dates
+    // match the provider event so the later details sync is a no-op for the
+    // schedule. ------------------------------------------------------------
+    const tournament = await adminCreateGolfTournament({
+      client: admin,
+      body: {
+        name: `The ${RUN} Championship`,
+        venue: 'Provider National',
+        location: 'Testshire',
+        startDate: MOCK_EVENT_START,
+        endDate: MOCK_EVENT_END,
+        rounds: 4,
+        releaseAt: '2026-05-20T00:00:00.000Z',
+        fieldLocksAt: '2026-05-27T16:00:00.000Z',
+        seasonId,
+        autoLifecycleEnabled: false,
+      },
+    });
+    expect(tournament.response?.status).toBe(201);
+    const eventId = tournament.data!.tournament.id;
+    created.sportEventIds.add(eventId);
+    expect(tournament.data!.tournament.syncScope).toBe('NONE');
+    expect(tournament.data!.tournament.source).toBe('MANUAL');
+    expect(tournament.data!.tournament.scoreSource).toBeNull();
+
+    // --- 1. Browse the provider's live catalog for the tournament window ---
+    const catalog = await adminListProviderCatalogEvents({
+      client: admin,
+      path: { providerId: MOCK_PROVIDER_ID },
+      query: {
+        sport: 'GOLF',
+        from: '2026-05-27T00:00:00.000Z',
+        to: '2026-05-29T00:00:00.000Z',
+      },
+    });
+    expect(catalog.response?.status).toBe(200);
+    const catalogEvents = catalog.data!.events;
+    expect(Array.isArray(catalogEvents)).toBe(true);
+    const usOpen = catalogEvents.find((e) => e.externalId === MOCK_EVENT_EXTERNAL_ID);
+    expect(usOpen).toBeDefined();
+    expect(usOpen!.name).toContain('U.S. Open');
+    expect(new Date(usOpen!.startDate).getUTCFullYear()).toBe(2026);
+    // Plain filtered list — the wall-clock-relative generated scenario is far
+    // outside this window, so it must not leak in.
+    expect(catalogEvents.every((e) => !e.externalId.startsWith('golf-relative-'))).toBe(true);
+
+    // matchKeyword (from the linked SportLeague) narrows the same browse.
+    const filtered = await adminListProviderCatalogEvents({
+      client: admin,
+      path: { providerId: MOCK_PROVIDER_ID },
+      query: {
+        sport: 'GOLF',
+        sportLeagueId,
+        from: '2026-04-01T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+    });
+    expect(filtered.response?.status).toBe(200);
+    expect(filtered.data!.events.length).toBeGreaterThan(0);
+    expect(filtered.data!.events.every((e) => e.name.includes('U.S. Open'))).toBe(true);
+
+    // --- 2. Link the manual-admin tournament's score source -------------
+    const link = await adminLinkGolfTournamentScoreSource({
+      client: admin,
+      path: { eventId },
+      body: { providerId: MOCK_PROVIDER_ID, externalId: MOCK_EVENT_EXTERNAL_ID },
+    });
+    expect(link.response?.status).toBe(200);
+    expect(link.data!.tournament.syncScope).toBe('SCORES_ONLY');
+    expect(link.data!.tournament.source).toBe('PROVIDER');
+    expect(link.data!.tournament.scoreSource).toEqual({
+      providerId: MOCK_PROVIDER_ID,
+      externalId: MOCK_EVENT_EXTERNAL_ID,
+    });
+
+    // Linking does not import the field.
+    const fieldAfterLink = await adminGetGolfTournamentField({ client: admin, path: { eventId } });
+    expect(fieldAfterLink.data!.entries.length).toBe(0);
+
+    // Failure path: a second manual-admin tournament cannot link the same
+    // provider event.
+    const rivalSeason = await adminCreateGolfSeason({
+      client: admin,
+      body: {
+        sportLeagueId,
+        name: `USGA ${RUN} rival`,
+        year: 2027,
+        startDate: '2027-04-01T00:00:00.000Z',
+        endDate: '2027-07-31T00:00:00.000Z',
+      },
+    });
+    created.seasonIds.add(rivalSeason.data!.season.id);
+    const rival = await adminCreateGolfTournament({
+      client: admin,
+      body: {
+        name: `Rival ${RUN} Championship`,
+        startDate: MOCK_EVENT_START,
+        endDate: MOCK_EVENT_END,
+        rounds: 4,
+        releaseAt: '2026-05-20T00:00:00.000Z',
+        fieldLocksAt: '2026-05-27T16:00:00.000Z',
+        seasonId: rivalSeason.data!.season.id,
+        autoLifecycleEnabled: false,
+      },
+    });
+    created.sportEventIds.add(rival.data!.tournament.id);
+    expectFunctionalError(
+      await adminLinkGolfTournamentScoreSource({
+        client: admin,
+        path: { eventId: rival.data!.tournament.id },
+        body: { providerId: MOCK_PROVIDER_ID, externalId: MOCK_EVENT_EXTERNAL_ID },
+      }),
+      { status: 409, code: 'EXTERNAL_EVENT_ALREADY_LINKED' },
+    );
+
+    // --- 3a. Load the field from the provider. EVENTPARTICIPANTS is allowed
+    // for a SCORES_ONLY event (plans/125 §3.2), so an admin refresh works and
+    // creates the provider-mapped participant identities the score sync needs.
+    const refresh = await adminRefreshGolfTournamentField({ client: admin, path: { eventId } });
+    expect(refresh.response?.status).toBe(202);
+    await waitForSyncRuns(refresh.data!.syncRuns.map((r) => r.id));
+
+    const loadedField = await adminGetGolfTournamentField({ client: admin, path: { eventId } });
+    // The mock provider pads the golf field from its scenario pool; assert a
+    // real field arrived and remember its exact size for the isolation checks.
+    const fieldSize = loadedField.data!.entries.length;
+    expect(fieldSize).toBeGreaterThanOrEqual(10);
+    const fieldSepIds = loadedField.data!.entries.map((e) => e.sportEventParticipantId).sort();
+
+    // The details sync never writes SportEvent.status (plans/124 §3.3).
+    const afterRefresh = await adminGetGolfTournament({ client: admin, path: { eventId } });
+    expect(afterRefresh.data!.tournament.status).toBe('SCHEDULED');
+    expect(afterRefresh.data!.tournament.syncScope).toBe('SCORES_ONLY');
+
+    // --- Make the loaded field contest-selectable: 2 tiers + auto assign --
+    expect(
+      (await adminReplaceGolfTournamentTiers({
+        client: admin,
+        path: { eventId },
+        body: {
+          tiers: [1, 2].map((n) => ({
+            tierKey: `tier-${n}`,
+            label: `Tier ${n}`,
+            tierNumber: n,
+            defaultPickCount: 2,
+          })),
+          reassignOrphansTo: 'tier-1',
+        },
+      })).response?.status,
+    ).toBe(200);
+    expect(
+      (await adminAutoAssignGolfTiers({ client: admin, path: { eventId }, body: { source: 'WORLD_RANK' } }))
+        .response?.status,
+    ).toBe(200);
+    expect(
+      (await adminAutoAssignGolfPrices({ client: admin, path: { eventId }, body: { minPrice: 1000, maxPrice: 10000 } }))
+        .response?.status,
+    ).toBe(200);
+
+    // --- 5a. League contest against the linked tournament (prisma fixture:
+    // the SDK managed-contest create path rejects an already-field-locked
+    // event, and z3l proved the authoring SDK surface separately — here the
+    // contest is a settlement fixture, not the thing under test). ---------
+    const contestId = await buildGolfContestFixture(eventId);
+
+    // --- 3b. Transition to live; the linked contest activates -----------
+    const toLive = await adminTransitionGolfTournament({
+      client: admin,
+      path: { eventId },
+      body: { toStatus: 'IN_PROGRESS' },
+    });
+    expect(toLive.response?.status).toBe(200);
+    expect(toLive.data!.tournament.status).toBe('IN_PROGRESS');
+
+    // --- 3c. One manual EVENTLIVESCORES sync tick -> R1 scores via sync -
+    const db = getFunctionalPrisma();
+    const r1Sync = await adminSyncProviderEventData({
+      client: admin,
+      path: { sport: 'GOLF', eventId: MOCK_EVENT_EXTERNAL_ID },
+      body: { feeds: ['EVENTLIVESCORES'], mockEventState: 'golf-r1-complete' },
+    });
+    expect(r1Sync.response?.status).toBe(202);
+    await waitForSyncRuns(r1Sync.data!.syncRuns.map((r) => r.id));
+
+    // Scores arrived via the sync path — adminApplyGolfRoundScores was never
+    // called anywhere in this scenario.
+    const seps = await db.sportEventParticipant.findMany({
+      where: { sportEventId: eventId },
+      select: { id: true },
+    });
+    const sepIds = seps.map((s) => s.id);
+    expect(sepIds.length).toBe(fieldSize);
+    const standings = await db.sportEventParticipantGolfStanding.findMany({
+      where: { sportEventParticipantId: { in: sepIds } },
+    });
+    expect(standings.length).toBe(fieldSize);
+    expect(standings.every((s) => Number.isInteger(s.eventScoreToPar) && Number.isInteger(s.eventStrokes))).toBe(true);
+
+    const round1 = await db.sportEventRound.findFirstOrThrow({
+      where: { sportEventId: eventId, roundNumber: 1 },
+      select: { id: true },
+    });
+    const r1RoundRows = await db.sportEventParticipantGolfRound.findMany({
+      where: { sportEventParticipantId: { in: sepIds }, sportEventRoundId: round1.id },
+    });
+    expect(r1RoundRows.length).toBe(fieldSize);
+
+    const liveScoreRun = await db.providerSyncRun.findFirst({
+      where: { eventId: MOCK_EVENT_EXTERNAL_ID, providerId: MOCK_PROVIDER_ID, status: 'COMPLETED' },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(liveScoreRun).not.toBeNull();
+
+    // --- 4. Score-sync isolation: the field is untouched by the tick ---
+    const fieldAfterSync = await adminGetGolfTournamentField({ client: admin, path: { eventId } });
+    expect(fieldAfterSync.data!.entries.map((e) => e.sportEventParticipantId).sort()).toEqual(fieldSepIds);
+    expect(fieldAfterSync.data!.entries.every((e) => e.isActive)).toBe(true);
+
+    // --- 5b. Drive to the finish, then COMPLETED -> settlement fires ---
+    const finalSync = await adminSyncProviderEventData({
+      client: admin,
+      path: { sport: 'GOLF', eventId: MOCK_EVENT_EXTERNAL_ID },
+      body: { feeds: ['EVENTLIVESCORES'], mockEventState: 'golf-completed' },
+    });
+    expect(finalSync.response?.status).toBe(202);
+    await waitForSyncRuns(finalSync.data!.syncRuns.map((r) => r.id));
+
+    const toDone = await adminTransitionGolfTournament({
+      client: admin,
+      path: { eventId },
+      body: { toStatus: 'COMPLETED' },
+    });
+    expect(toDone.response?.status).toBe(200);
+    expect(toDone.data!.tournament.status).toBe('COMPLETED');
+
+    const settlement = await db.contestEntryGolfStanding.findMany({ where: { contestId } });
+    expect(settlement.length).toBeGreaterThanOrEqual(1);
+    expect(settlement.every((s) => Number.isInteger(s.totalScoreToPar))).toBe(true);
+    expect(settlement.every((s) => s.status === 'FINAL')).toBe(true);
+    const settledContest = await db.contest.findUniqueOrThrow({ where: { id: contestId } });
+    expect(settledContest.status).toBe('COMPLETED');
+
+    // --- 6. Unlink, then a further sync tick does not touch the data ---
+    const standingsBefore = await db.sportEventParticipantGolfStanding.findMany({
+      where: { sportEventParticipantId: { in: sepIds } },
+      orderBy: { sportEventParticipantId: 'asc' },
+    });
+    const roundsBefore = await db.sportEventParticipantGolfRound.count({
+      where: { sportEventParticipantId: { in: sepIds } },
+    });
+
+    const unlink = await adminUnlinkGolfTournamentScoreSource({ client: admin, path: { eventId } });
+    expect(unlink.response?.status).toBe(200);
+    expect(unlink.data!.tournament.syncScope).toBe('NONE');
+    expect(unlink.data!.tournament.source).toBe('MANUAL');
+    expect(unlink.data!.tournament.scoreSource).toBeNull();
+    const unlinkedRow = await db.sportEvent.findUniqueOrThrow({ where: { id: eventId } });
+    expect(unlinkedRow.providerId).toBe('manual-admin');
+    expect(unlinkedRow.externalId.startsWith('manual-')).toBe(true);
+
+    // The mock externalId no longer resolves to any SportEvent row: the tick
+    // is accepted but persists nothing against the now-unlinked tournament.
+    const staleSync = await adminSyncProviderEventData({
+      client: admin,
+      path: { sport: 'GOLF', eventId: MOCK_EVENT_EXTERNAL_ID },
+      body: { feeds: ['EVENTLIVESCORES'], mockEventState: 'golf-late-correction' },
+    });
+    expect(staleSync.response?.status).toBe(202);
+    await waitForSyncRuns(staleSync.data!.syncRuns.map((r) => r.id));
+
+    const standingsAfter = await db.sportEventParticipantGolfStanding.findMany({
+      where: { sportEventParticipantId: { in: sepIds } },
+      orderBy: { sportEventParticipantId: 'asc' },
+    });
+    const roundsAfter = await db.sportEventParticipantGolfRound.count({
+      where: { sportEventParticipantId: { in: sepIds } },
+    });
+    expect(roundsAfter).toBe(roundsBefore);
+    expect(standingsAfter.map((s) => [s.sportEventParticipantId, s.eventScoreToPar, s.eventStrokes])).toEqual(
+      standingsBefore.map((s) => [s.sportEventParticipantId, s.eventScoreToPar, s.eventStrokes]),
+    );
+
+    const finalDetail = await adminGetGolfTournament({ client: admin, path: { eventId } });
+    expect(finalDetail.data!.tournament.syncScope).toBe('NONE');
+    const finalTiers = await adminGetGolfTournamentTiers({ client: admin, path: { eventId } });
+    expect(finalTiers.data!.tiers.length).toBe(2);
+  }, 120_000);
+
+  it('BR-GOLF-ADMIN-AUTHZ: provider-link operations reject a non-root-admin caller with 403', async () => {
+    const member = await buildRegisteredUser({ displayName: 'Golf Provider Non Admin' });
+    created.userIds.add(member.userId);
+    const c = member.client;
+    const deny = { status: 403, code: 'ROOT_ADMIN_ACCESS_REQUIRED' };
+
+    expectFunctionalError(
+      await adminListProviderCatalogEvents({
+        client: c,
+        path: { providerId: MOCK_PROVIDER_ID },
+        query: { sport: 'GOLF' },
+      }),
+      deny,
+    );
+    expectFunctionalError(
+      await adminLinkGolfTournamentScoreSource({
+        client: c,
+        path: { eventId: 'x' },
+        body: { providerId: MOCK_PROVIDER_ID, externalId: MOCK_EVENT_EXTERNAL_ID },
+      }),
+      deny,
+    );
+    expectFunctionalError(
+      await adminUnlinkGolfTournamentScoreSource({ client: c, path: { eventId: 'x' } }),
+      deny,
+    );
+    expectFunctionalError(
+      await adminRefreshGolfTournamentField({ client: c, path: { eventId: 'x' } }),
+      deny,
+    );
+    expectFunctionalError(
+      await adminSyncProviderEventData({
+        client: c,
+        path: { sport: 'GOLF', eventId: MOCK_EVENT_EXTERNAL_ID },
+        body: { feeds: ['EVENTLIVESCORES'] },
+      }),
+      deny,
+    );
+  });
+});
+
+/**
+ * Builds a minimal ACTIVE golf ROSTER/TIERED contest against `sportEventId`
+ * with one entry whose picks reference the three current world-rank leaders in
+ * the (provider-loaded) field — mirroring golf-contest-settlement.integration
+ * .ts's fixture. Settlement is driven by the real COMPLETED transition, not a
+ * direct service call.
+ */
+async function buildGolfContestFixture(sportEventId: string): Promise<string> {
+  const db = getFunctionalPrisma();
+  const suffix = randomUUID().slice(0, 8);
+  const owner = await buildRegisteredUser({ displayName: `Provider Contest Owner ${suffix}` });
+  created.userIds.add(owner.userId);
+
+  const league = await db.league.create({
+    data: {
+      leagueCode: `CS8${suffix.toUpperCase()}`,
+      name: `Provider Linked ${RUN} ${suffix}`,
+      createdBy: owner.userId,
+    },
+  });
+  created.leagueIds.add(league.id);
+  await db.leagueMembership.create({
+    data: {
+      leagueId: league.id,
+      userId: owner.userId,
+      role: 'COMMISSIONER',
+      status: 'ACTIVE',
+      joinedAt: new Date(),
+    },
+  });
+  const squad = await db.squad.create({
+    data: { leagueId: league.id, createdBy: owner.userId, name: `Provider Squad ${suffix}` },
+  });
+  created.squadIds.add(squad.id);
+  await db.squadMembership.create({
+    data: { leagueId: league.id, squadId: squad.id, userId: owner.userId, status: 'ACTIVE' },
+  });
+
+  const contest = await db.contest.create({
+    data: {
+      leagueId: league.id,
+      sportEventId,
+      name: `Provider Linked Contest ${RUN} ${suffix}`,
+      status: 'ACTIVE',
+      contestFormat: 'ROSTER',
+      selectionType: 'TIERED',
+      scoringEngine: 'STROKE_PLAY',
+    },
+  });
+  created.contestIds.add(contest.id);
+  await db.contestConfiguration.create({
+    data: {
+      contestId: contest.id,
+      selectionType: 'TIERED',
+      configJson: { countedScores: 2 },
+      rosterSize: 3,
+      pickCount: 3,
+    },
+  });
+
+  const entry = await db.contestEntry.create({
+    data: {
+      contestId: contest.id,
+      squadId: squad.id,
+      entryNumber: 1,
+      name: `Provider Entry ${suffix}`,
+      status: 'ACTIVE',
+    },
+  });
+
+  const field = await db.sportEventParticipant.findMany({
+    where: { sportEventId },
+    orderBy: { worldRanking: 'asc' },
+    select: { id: true },
+    take: 3,
+  });
+  await db.contestEntryPick.createMany({
+    data: field.map((sep, index) => ({
+      entryId: entry.id,
+      sportEventParticipantId: sep.id,
+      contestFormat: 'ROSTER' as const,
+      slot: index + 1,
+    })),
+  });
+
+  return contest.id;
+}

--- a/tests/functional/golf-admin-provider-linked.functional.ts
+++ b/tests/functional/golf-admin-provider-linked.functional.ts
@@ -53,10 +53,13 @@ import {
 // SCORES_ONLY event" assertion the epic narrative mentions is a
 // scheduled-event-reader concern, not reachable through the SDK — the manual
 // event-sync endpoint deliberately *permits* EVENTPARTICIPANTS for SCORES_ONLY
-// (plans/125 §3.2; unit: admin-support-services.test.ts "pool-master-5h3").
-// The scheduled per-feed syncScope gate is covered by
-// scheduled-event-reader.test.ts "pool-master-cgb" and by
-// mock-contest-feed-provider.integration.ts "pool-master-rop.68.1.7".
+// (plans/125 §3.2). Existing coverage for the real behaviour:
+//   - admin-support-services.test.ts "pool-master-5h3" — the manual event-sync
+//     guard permits EVENTPARTICIPANTS for SCORES_ONLY (rejects only NONE).
+//   - scheduled-event-reader.test.ts "pool-master-cgb" — the *scheduled* per-feed
+//     syncScope gate: EVENTPARTICIPANTS never returns a NONE/SCORES_ONLY event.
+//   - mock-contest-feed-provider.integration.ts "pool-master-rop.68.1.7" — the
+//     same gate end to end through listEventIdsForFeed.
 
 const MOCK_PROVIDER_ID = 'mock-contest-feed';
 // A fixed, dateable event from the static golf-major-2026 scenario — never the
@@ -123,6 +126,13 @@ async function waitForSyncRuns(ids: string[]): Promise<void> {
 async function cleanup(): Promise<void> {
   const db = getFunctionalPrisma();
 
+  // ASSUMPTION: functional tests run maxWorkers: 1 (tests/functional/jest.config.js)
+  // and this is the only provider-linked functional suite, so the deletes below
+  // that key off MOCK_PROVIDER_ID / MOCK_EVENT_EXTERNAL_ID rather than this run's
+  // RUN stamp (the ingestionJob sweep, and the sport_events match on the fixed
+  // golf-us-open-2026 externalId) cannot race a sibling suite. A second
+  // provider-linked functional suite must scope its own mock rows by RUN (or a
+  // per-suite externalId) and this sweep must be tightened alongside it.
   const byName = await db.sportEvent.findMany({
     where: { OR: [{ name: { contains: RUN } }, { externalId: MOCK_EVENT_EXTERNAL_ID, providerId: MOCK_PROVIDER_ID }] },
     select: { id: true },
@@ -482,6 +492,19 @@ describe('SDK Functional: Golf provider-linked live scoring + settlement (pool-m
     expect(fieldAfterSync.data!.entries.every((e) => e.isActive)).toBe(true);
 
     // --- 5b. Drive to the finish, then COMPLETED -> settlement fires ---
+    // The tournament was authored with 4 rounds and the details sync (§3a) left
+    // that untouched. The 'golf-completed' mock state, however, synthesizes a
+    // 2-player playoff as round 5, and golf-score-service.persistRoundUpdates
+    // auto-creates a SportEventRound for any incoming round number it can't
+    // resolve — so the score sync DOES add one round row beyond the authored
+    // schedule. That auto-create is a pre-existing golf-score-service behaviour
+    // (logged liveScore.golf.autoCreatedRoundSchedule) and the same
+    // "provider payload bleeds past a SCORES_ONLY link" class as the schedule
+    // overwrite tracked in pool-master-ce4 — asserted explicitly here so a
+    // future reader isn't surprised by the 4 -> 5 drift.
+    const roundsBeforeFinalSync = await db.sportEventRound.count({ where: { sportEventId: eventId } });
+    expect(roundsBeforeFinalSync).toBe(4);
+
     const finalSync = await adminSyncProviderEventData({
       client: admin,
       path: { sport: 'GOLF', eventId: MOCK_EVENT_EXTERNAL_ID },
@@ -489,6 +512,9 @@ describe('SDK Functional: Golf provider-linked live scoring + settlement (pool-m
     });
     expect(finalSync.response?.status).toBe(202);
     await waitForSyncRuns(finalSync.data!.syncRuns.map((r) => r.id));
+
+    const roundsAfterFinalSync = await db.sportEventRound.count({ where: { sportEventId: eventId } });
+    expect(roundsAfterFinalSync).toBe(5); // +1: the auto-created playoff round
 
     const toDone = await adminTransitionGolfTournament({
       client: admin,

--- a/tests/functional/server.ts
+++ b/tests/functional/server.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
+import type { FastifyInstance } from 'fastify';
 import { buildApp } from '../../packages/core-api/src/index';
+import { buildApp as buildMockContestFeedProvider } from '../../packages/mock-contest-feed-provider/src/app';
 import { startSmtpSinkServer, type SmtpSinkServer } from '../support/smtp-sink';
 
 const stateFilePath = process.env.FUNCTIONAL_SERVER_STATE_FILE;
@@ -12,6 +14,26 @@ if (!stateFilePath) {
 }
 
 let smtpSink: SmtpSinkServer | undefined;
+// pool-master-cs8 — the FAPI daemon runs a real mock-contest-feed provider so
+// provider-linked golf scenarios (catalog browse, score-source link, sync-driven
+// live scores) can be driven end to end through the generated SDK, the same way
+// the deployed QA stack runs poolmaster-qa-mock-contest-feed-provider alongside
+// core-api. It is registered for GOLF/TENNIS/NCAA_BASKETBALL but only ever
+// touched by requests that explicitly hit the provider/sync surface, so it is
+// inert for every other functional test.
+let mockContestFeedProvider: FastifyInstance | undefined;
+
+async function startMockContestFeedProviderForDaemon(): Promise<string> {
+  const provider = buildMockContestFeedProvider();
+  await provider.listen({ host: '127.0.0.1', port: 0 });
+  const address = provider.server.address();
+  if (!address || typeof address === 'string') {
+    await provider.close();
+    throw new Error('Mock contest feed provider failed to bind to a TCP port');
+  }
+  mockContestFeedProvider = provider;
+  return `http://127.0.0.1:${address.port}`;
+}
 
 // Daemon's state file lives at `<coverage>/service-functional-api/daemon/server-state.json`.
 // Per-run state files live at `<coverage>/service-functional-api/runs/<id>/server-state.json`.
@@ -83,6 +105,14 @@ async function main(): Promise<void> {
   delete process.env.SMTP_USERNAME;
   delete process.env.SMTP_PASSWORD;
 
+  // Register the mock provider before buildApp() — registerConfiguredProviders
+  // reads these env vars once, at construction time (pool-master-cs8).
+  const mockProviderBaseUrl = await startMockContestFeedProviderForDaemon();
+  process.env.SPORT_DATA_DEFAULT_PROVIDER = 'mock-contest-feed';
+  process.env.SPORT_DATA_PROVIDER_BINDINGS_JSON = JSON.stringify({
+    providers: { 'mock-contest-feed': { baseUrl: mockProviderBaseUrl } },
+  });
+
   const app = buildApp();
 
   await app.ready();
@@ -106,6 +136,7 @@ async function main(): Promise<void> {
     try {
       await app.close();
     } finally {
+      await mockContestFeedProvider?.close().catch(() => undefined);
       await smtpSink?.close().catch(() => undefined);
       process.exit(0);
     }
@@ -165,6 +196,7 @@ async function main(): Promise<void> {
 
 main().catch(async (error) => {
   process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  await mockContestFeedProvider?.close().catch(() => undefined);
   await smtpSink?.close().catch(() => undefined);
   if (stateFilePath) {
     await fs.rm(stateFilePath, { force: true }).catch(() => undefined);

--- a/tests/integration/core-api/contract-verification-root-admin.integration.ts
+++ b/tests/integration/core-api/contract-verification-root-admin.integration.ts
@@ -19,6 +19,7 @@ import {
   AdminGolfTournamentListResponseSchema,
   AdminGolfTournamentRoundsResponseSchema,
   AdminGolfTournamentTiersResponseSchema,
+  AdminListProviderCatalogEventsResponseSchema,
   AdminSetCurrentGolfSeasonResponseSchema,
   LeagueListResponseSchema,
   LeagueResponseSchema,
@@ -252,6 +253,38 @@ async function buildOperationalAdminApp(): Promise<FastifyInstance> {
   await app.register(adminModule, {
     prefix: '/api/v1/admin',
     providerService,
+  });
+  await app.ready();
+
+  return app;
+}
+
+/**
+ * Like buildOperationalAdminApp but also hands the admin module the provider
+ * registry, so the golf score-source lane's EventScoreSourceService can resolve
+ * the registered provider for adminListProviderCatalogEvents (pool-master-cs8).
+ */
+async function buildScoreSourceContractApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  const registry = new ProviderRegistry();
+  registry.register('GOLF', new OperationalContractProvider(), 'PRIMARY');
+  const scheduler = new IngestionScheduler(registry, {
+    onEvents: async () => undefined,
+    onEventDetail: async () => undefined,
+    onRankings: async () => undefined,
+    onLiveScores: async () => emptyLiveScorePersistenceResult(),
+    onJobComplete: async () => undefined,
+  }, undefined, {
+    now: () => new Date('2026-04-05T12:00:00.000Z'),
+  });
+  const providerService = new ProviderService(getPrisma(), registry, scheduler);
+
+  app.decorate('prisma', getPrisma());
+  app.setErrorHandler(globalErrorHandler);
+  await app.register(adminModule, {
+    prefix: '/api/v1/admin',
+    providerService,
+    providerRegistry: registry,
   });
   await app.ready();
 
@@ -1359,6 +1392,149 @@ describe('Contract verification (root admin)', () => {
       if (created.sportLeagueId) {
         await prisma.sportLeague.deleteMany({ where: { id: created.sportLeagueId } });
       }
+    }
+  });
+
+  it('pool-master-cs8: root-admin golf score-source + provider-catalog routes match their DTOs on happy paths', async () => {
+    // plans/124 §8 — a happy-path contract case for the three provider-linked
+    // operations the epic's flagship FAPI scenario left uncovered:
+    // adminListProviderCatalogEvents, adminLinkGolfTournamentScoreSource,
+    // adminUnlinkGolfTournamentScoreSource. Drives one coherent flow through a
+    // dedicated admin app with a registered provider and safeParses every
+    // response against its published schema. Golf admin rows are not covered by
+    // cleanupTestData(), so this test tears down child-first in a finally block.
+    const app = await buildScoreSourceContractApp();
+    const rootAdmin = await createTestUser({
+      displayName: 'Root Admin Golf Score Source Contract User',
+      isRootAdmin: true,
+    });
+    const stamp = Date.now().toString().slice(-8);
+
+    await getPrisma().sport.upsert({
+      where: { name: 'GOLF' },
+      create: {
+        name: 'GOLF',
+        participantType: 'INDIVIDUAL',
+        category: 'GOLF',
+        tournamentFormat: 'STROKE_PLAY_TOURNAMENT',
+      },
+      update: {},
+    });
+
+    const created = {
+      sportLeagueId: '',
+      seasonId: '',
+      eventIds: [] as string[],
+    };
+
+    try {
+      // --- adminListProviderCatalogEvents (200) --------------------------
+      const catalogRes = await app.inject({
+        method: 'GET',
+        url: '/api/v1/admin/providers/contract-provider/catalog-events?sport=GOLF&from=2026-04-01T00:00:00.000Z&to=2026-04-30T00:00:00.000Z',
+        headers: rootAdmin.headers,
+      });
+      expect(catalogRes.statusCode).toBe(200);
+      expect(AdminListProviderCatalogEventsResponseSchema.safeParse(catalogRes.json()).success).toBe(true);
+      expect(
+        catalogRes.json().events.some((e: { externalId: string }) => e.externalId === 'event-1'),
+      ).toBe(true);
+
+      // --- tour -> season -> manual-admin tournament (syncScope NONE) ----
+      const leagueRes = await app.inject({
+        method: 'POST',
+        url: '/api/v1/admin/sports/golf/leagues',
+        headers: rootAdmin.headers,
+        payload: { name: `CS8 Contract Tour ${stamp}`, matchKeyword: `CS8${stamp}` },
+      });
+      expect(leagueRes.statusCode).toBe(201);
+      created.sportLeagueId = leagueRes.json().league.id as string;
+
+      const seasonRes = await app.inject({
+        method: 'POST',
+        url: '/api/v1/admin/sports/golf/seasons',
+        headers: rootAdmin.headers,
+        payload: {
+          sportLeagueId: created.sportLeagueId,
+          name: `CS8 Contract Season ${stamp} 2083`,
+          year: 2083,
+          startDate: '2083-01-05T00:00:00.000Z',
+          endDate: '2083-11-30T00:00:00.000Z',
+        },
+      });
+      expect(seasonRes.statusCode).toBe(201);
+      created.seasonId = seasonRes.json().season.id as string;
+
+      const tournamentRes = await app.inject({
+        method: 'POST',
+        url: '/api/v1/admin/sports/golf/tournaments',
+        headers: rootAdmin.headers,
+        payload: {
+          name: `CS8 Contract Open ${stamp}`,
+          startDate: '2083-06-16T08:00:00.000Z',
+          endDate: '2083-06-19T20:00:00.000Z',
+          rounds: 4,
+          releaseAt: '2083-06-01T00:00:00.000Z',
+          fieldLocksAt: '2083-06-15T00:00:00.000Z',
+          seasonId: created.seasonId,
+          autoLifecycleEnabled: false,
+        },
+      });
+      expect(tournamentRes.statusCode).toBe(201);
+      const eventId = tournamentRes.json().tournament.id as string;
+      created.eventIds.push(eventId);
+      expect(tournamentRes.json().tournament.syncScope).toBe('NONE');
+
+      // --- adminLinkGolfTournamentScoreSource (200) --------------------
+      const linkRes = await app.inject({
+        method: 'POST',
+        url: `/api/v1/admin/sports/golf/tournaments/${eventId}/score-source`,
+        headers: rootAdmin.headers,
+        payload: { providerId: 'contract-provider', externalId: `contract-cs8-${stamp}` },
+      });
+      expect(linkRes.statusCode).toBe(200);
+      expect(AdminGolfTournamentDetailResponseSchema.safeParse(linkRes.json()).success).toBe(true);
+      expect(linkRes.json().tournament.syncScope).toBe('SCORES_ONLY');
+      expect(linkRes.json().tournament.source).toBe('PROVIDER');
+      expect(linkRes.json().tournament.scoreSource).toEqual({
+        providerId: 'contract-provider',
+        externalId: `contract-cs8-${stamp}`,
+      });
+
+      // --- adminUnlinkGolfTournamentScoreSource (200) -----------------
+      const unlinkRes = await app.inject({
+        method: 'DELETE',
+        url: `/api/v1/admin/sports/golf/tournaments/${eventId}/score-source`,
+        headers: withoutJsonBodyHeaders(rootAdmin.headers),
+      });
+      expect(unlinkRes.statusCode).toBe(200);
+      expect(AdminGolfTournamentDetailResponseSchema.safeParse(unlinkRes.json()).success).toBe(true);
+      expect(unlinkRes.json().tournament.syncScope).toBe('NONE');
+      expect(unlinkRes.json().tournament.source).toBe('MANUAL');
+      expect(unlinkRes.json().tournament.scoreSource).toBeNull();
+    } finally {
+      const prisma = getPrisma();
+      if (created.eventIds.length) {
+        await prisma.sportEventRound.deleteMany({ where: { sportEventId: { in: created.eventIds } } });
+        await prisma.sportEventGolfTier.deleteMany({ where: { sportEventId: { in: created.eventIds } } });
+        await prisma.sportEvent.deleteMany({ where: { id: { in: created.eventIds } } });
+      }
+      if (created.sportLeagueId) {
+        await prisma.sportLeague.updateMany({
+          where: { id: created.sportLeagueId },
+          data: { currentSeasonId: null },
+        });
+        await prisma.leagueEvent.deleteMany({ where: { sportLeagueId: created.sportLeagueId } });
+      }
+      if (created.seasonId || created.sportLeagueId) {
+        await prisma.season.deleteMany({
+          where: created.sportLeagueId ? { sportLeagueId: created.sportLeagueId } : { id: created.seasonId },
+        });
+      }
+      if (created.sportLeagueId) {
+        await prisma.sportLeague.deleteMany({ where: { id: created.sportLeagueId } });
+      }
+      await app.close();
     }
   });
 });

--- a/tests/integration/core-api/contract-verification-root-admin.integration.ts
+++ b/tests/integration/core-api/contract-verification-root-admin.integration.ts
@@ -233,38 +233,15 @@ class EmptyDiagnosticsProvider extends OperationalContractProvider implements Pr
   }
 }
 
-async function buildOperationalAdminApp(): Promise<FastifyInstance> {
-  const app = Fastify({ logger: false });
-  const registry = new ProviderRegistry();
-  registry.register('GOLF', new OperationalContractProvider(), 'PRIMARY');
-  const scheduler = new IngestionScheduler(registry, {
-    onEvents: async () => undefined,
-    onEventDetail: async () => undefined,
-    onRankings: async () => undefined,
-    onLiveScores: async () => emptyLiveScorePersistenceResult(),
-    onJobComplete: async () => undefined,
-  }, undefined, {
-    now: () => new Date('2026-04-05T12:00:00.000Z'),
-  });
-  const providerService = new ProviderService(getPrisma(), registry, scheduler);
-
-  app.decorate('prisma', getPrisma());
-  app.setErrorHandler(globalErrorHandler);
-  await app.register(adminModule, {
-    prefix: '/api/v1/admin',
-    providerService,
-  });
-  await app.ready();
-
-  return app;
-}
-
 /**
- * Like buildOperationalAdminApp but also hands the admin module the provider
- * registry, so the golf score-source lane's EventScoreSourceService can resolve
- * the registered provider for adminListProviderCatalogEvents (pool-master-cs8).
+ * `exposeRegistry` also hands the admin module the provider registry, so the
+ * golf score-source lane's EventScoreSourceService can resolve the registered
+ * provider for adminListProviderCatalogEvents (pool-master-cs8). Off by default
+ * — the operational-sync cases only exercise providerService.
  */
-async function buildScoreSourceContractApp(): Promise<FastifyInstance> {
+async function buildOperationalAdminApp(
+  { exposeRegistry = false }: { exposeRegistry?: boolean } = {},
+): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
   const registry = new ProviderRegistry();
   registry.register('GOLF', new OperationalContractProvider(), 'PRIMARY');
@@ -284,7 +261,7 @@ async function buildScoreSourceContractApp(): Promise<FastifyInstance> {
   await app.register(adminModule, {
     prefix: '/api/v1/admin',
     providerService,
-    providerRegistry: registry,
+    ...(exposeRegistry ? { providerRegistry: registry } : {}),
   });
   await app.ready();
 
@@ -1403,7 +1380,7 @@ describe('Contract verification (root admin)', () => {
     // dedicated admin app with a registered provider and safeParses every
     // response against its published schema. Golf admin rows are not covered by
     // cleanupTestData(), so this test tears down child-first in a finally block.
-    const app = await buildScoreSourceContractApp();
+    const app = await buildOperationalAdminApp({ exposeRegistry: true });
     const rootAdmin = await createTestUser({
       displayName: 'Root Admin Golf Score Source Contract User',
       isRootAdmin: true,
@@ -1486,6 +1463,9 @@ describe('Contract verification (root admin)', () => {
       expect(tournamentRes.json().tournament.syncScope).toBe('NONE');
 
       // --- adminLinkGolfTournamentScoreSource (200) --------------------
+      // A shape test: linkScoreSource only guards against an externalId already
+      // held by another SportEvent (409 EXTERNAL_EVENT_ALREADY_LINKED), not
+      // against provider-event existence — so a synthetic externalId links fine.
       const linkRes = await app.inject({
         method: 'POST',
         url: `/api/v1/admin/sports/golf/tournaments/${eventId}/score-source`,


### PR DESCRIPTION
## Summary

The provider-linked half of the golf-admin FAPI coverage that the `pool-master-z3l` flagship deliberately skipped (plans/124 §8). Test-only — no source changes.

Bead `pool-master-cs8` (closed, "done — ready for review"). Rebased onto current `main` (the `pool-master-54u` tier-count fix); `.beads/issues.jsonl` conflicts resolved by taking `main`'s copy.

## What's added

**1. `tests/functional/server.ts` (+32)** — the shared FAPI daemon now boots `@poolmaster/mock-contest-feed-provider`'s `buildApp()` on an ephemeral `127.0.0.1` port alongside the SMTP sink, sets `SPORT_DATA_DEFAULT_PROVIDER=mock-contest-feed` + `SPORT_DATA_PROVIDER_BINDINGS_JSON` before core-api boot so `registerConfiguredProviders` wires it for GOLF/TENNIS/NCAA_BASKETBALL, and closes it on shutdown + the `main().catch` path. One process, one lifecycle, shared across concurrent runs — mirrors the deployed QA topology. Verified inert for every existing functional test (no other functional test drives a real provider sync).

**2. `tests/functional/golf-admin-provider-linked.functional.ts` (new, 707 lines, 2 tests)** — driven through the generated SDK:
- **UC-GOLF-ADMIN-03/04**: create league/season/manual tournament → provider catalog browse (matchKeyword narrowing, no generated-scenario leakage) → link score source (`syncScope SCORES_ONLY` / `source PROVIDER`, no field import) → duplicate-link `409 EXTERNAL_EVENT_ALREADY_LINKED` → refresh field via provider (202 → poll to terminal, field loaded, status untouched) → tiers/prices auto-assign → minimal ACTIVE contest fixture → `IN_PROGRESS` → `adminSyncProviderEventData(EVENTLIVESCORES, golf-r1-complete)` → standings + round rows arrive via the **sync path** (`adminApplyGolfRoundScores` never called) → score-sync isolation check (SEP set + isActive byte-identical) → `golf-completed` → `COMPLETED` → `ContestEntryGolfStanding` settlement fires, contest `COMPLETED` → unlink reverts to `syncScope NONE` / `manual-admin` identity → post-unlink sync against the orphaned externalId is accepted but writes nothing.
- **BR-GOLF-ADMIN-AUTHZ**: catalog-events / link / unlink / refresh-field / sync-event each `403 ROOT_ADMIN_ACCESS_REQUIRED` for a non-root-admin.
- Custom child-first `afterAll` cleanup (the shared functional teardown doesn't touch manual-admin / mock-contest-feed golf rows); verified leak-free.

**3. `tests/integration/core-api/contract-verification-root-admin.integration.ts` (+158)** — `pool-master-cs8` case + `buildScoreSourceContractApp` helper covering the 3 score-source operations z3l left uncovered: `GET .../catalog-events`, `POST .../score-source`, `DELETE .../score-source` — each `safeParse`d against its response DTO.

## Gates (re-run after rebase, from the worktree)

- `npx prisma generate` · `npx turbo typecheck --force` — 6/6
- `eslint` on the changed files — clean
- integration `contract-verification-root-admin` — **11/11** (incl. new `pool-master-cs8` case)
- full `test:service:functional-api` — **11 suites / 62 tests** (was 10/60; +1 suite, +2 tests are this PR)

## Riley findings

<!-- riley:findings -->

Implementer self-check (Pass 1). Test-only change; the one behavioural surface is `tests/functional/server.ts` starting a real provider process in the FAPI daemon.

| Severity | Category | Finding | Location |
|---|---|---|---|
| Info | scope | FAPI daemon now runs a second process (mock-contest-feed provider) for the whole functional suite. Verified inert for existing tests and closed on both shutdown paths; mirrors QA. | `tests/functional/server.ts` |
| Info | test-infra | New scenario uses a Prisma-built contest fixture rather than the managed-contest SDK path (documented in the bead's "gaps" note — managed-contest golf entry isn't wired yet). | `tests/functional/golf-admin-provider-linked.functional.ts` |

No blockers in self-review. Cross-model Pass 2 still warranted.
